### PR TITLE
[CO] extended search for find_cell + minor changes

### DIFF
--- a/pyleecan/Classes/CellMat.py
+++ b/pyleecan/Classes/CellMat.py
@@ -101,7 +101,7 @@ class CellMat(FrozenClass):
         nb_cell=0,
         nb_pt_per_cell=0,
         indice=[],
-        interpolation=None,
+        interpolation=-1,
         init_dict=None,
         init_str=None,
     ):

--- a/pyleecan/Classes/Class_Dict.json
+++ b/pyleecan/Classes/Class_Dict.json
@@ -342,7 +342,7 @@
                 "name": "interpolation",
                 "type": "Interpolation",
                 "unit": "",
-                "value": null
+                "value": -1
             }
         ]
     },
@@ -7204,7 +7204,8 @@
             "jacobian",
             "grad_shape_function",
             "get_real_point",
-            "get_ref_point"
+            "get_ref_point",
+            "is_inside"
         ],
         "mother": "RefCell",
         "name": "RefTriangle3",

--- a/pyleecan/Classes/RefTriangle3.py
+++ b/pyleecan/Classes/RefTriangle3.py
@@ -41,6 +41,11 @@ try:
 except ImportError as error:
     get_ref_point = error
 
+try:
+    from ..Methods.Mesh.RefTriangle3.is_inside import is_inside
+except ImportError as error:
+    is_inside = error
+
 
 from ._check import InitUnKnowClassError
 
@@ -107,6 +112,17 @@ class RefTriangle3(RefCell):
         )
     else:
         get_ref_point = get_ref_point
+    # cf Methods.Mesh.RefTriangle3.is_inside
+    if isinstance(is_inside, ImportError):
+        is_inside = property(
+            fget=lambda x: raise_(
+                ImportError(
+                    "Can't use RefTriangle3 method is_inside: " + str(is_inside)
+                )
+            )
+        )
+    else:
+        is_inside = is_inside
     # save and copy methods are available in all object
     save = save
     copy = copy

--- a/pyleecan/Generator/ClassesRef/Mesh/CellMat.csv
+++ b/pyleecan/Generator/ClassesRef/Mesh/CellMat.csv
@@ -3,4 +3,4 @@ connectivity,,Matrix of connectivity for one element type,,ndarray,[],,,,Mesh,,a
 nb_cell,,Total number of elements,,int,0,,,,,,get_connectivity,,,
 nb_pt_per_cell,,Define the number of node per element,,int,0,,,,,,get_point2cell,,,
 indice,,Element indices,,ndarray,[],,,,,,is_exist,,,
-interpolation,,Define FEA interpolation,,Interpolation,None,,,,,,,,,
+interpolation,,Define FEA interpolation,,Interpolation,-1,,,,,,,,,

--- a/pyleecan/Generator/ClassesRef/Mesh/Interpolation/RefTriangle3.csv
+++ b/pyleecan/Generator/ClassesRef/Mesh/Interpolation/RefTriangle3.csv
@@ -4,3 +4,4 @@ Variable name,Unit,Description (EN),Size,Type,Default value,Minimum value,Maximu
 ,,,,,,,,,,,grad_shape_function,,,
 ,,,,,,,,,,,get_real_point,,,
 ,,,,,,,,,,,get_ref_point,,,
+,,,,,,,,,,,is_inside,,,

--- a/pyleecan/Methods/Mesh/MeshMat/find_cell.py
+++ b/pyleecan/Methods/Mesh/MeshMat/find_cell.py
@@ -21,7 +21,7 @@ def find_cell(self, points, nb_pt, normal_t=None):
         A list of  of selected cells
 
     """
-    nmax_search = 3
+    # nmax_search = 3
     cells_list = list()
     cell_prop = list()
 
@@ -36,13 +36,15 @@ def find_cell(self, points, nb_pt, normal_t=None):
             pt = points[ii, :]
         for key in self.cell:
             cells = self.cell[key]
+            ref_cell = cells.interpolation.ref_cell
             connect = cells.connectivity
-            vertice0 = point_coord[connect[0]]
-            dist_ref = np.sqrt(
-                np.square(vertice0[0, 0] - vertice0[1, 0])
-                + np.square(vertice0[0, 1] - vertice0[1, 1])
-            )
+            # vertice0 = point_coord[connect[0]]
+            # dist_ref = np.sqrt(
+            #     np.square(vertice0[0, 0] - vertice0[1, 0])
+            #     + np.square(vertice0[0, 1] - vertice0[1, 1])
+            # )
 
+            # compute the distance of all nodes to the current point 'pt'
             point_rep = np.tile(pt, (nb_tot_pt, 1))
             dist_node = np.reshape(
                 np.sqrt(
@@ -59,17 +61,17 @@ def find_cell(self, points, nb_pt, normal_t=None):
             # All selected nodes from the closest to the farthest are tested
             inode = 0
             # dontstop = True
-            cell_prop = list()
+
             # while inode < nmax_search and inode < nb_tot_pt and dontstop:
+
+            # get cells that contain the closest node and test if point is inside
             closest_cells = np.where(connect == Imin_node[inode])[0]
             nb_closest_elem = len(closest_cells)
-            a = np.zeros(nb_closest_elem)
-            b = np.zeros(nb_closest_elem)
+            a, b = np.zeros(nb_closest_elem), np.zeros(nb_closest_elem)
+            cell_prop = list()
             for ielt in range(nb_closest_elem):
                 vert = self.get_vertice(closest_cells[ielt])[key]
-                (is_inside, a[ielt], b[ielt]) = cells.interpolation.ref_cell.is_inside(
-                    vert, pt, normal_t
-                )
+                (is_inside, a[ielt], b[ielt]) = ref_cell.is_inside(vert, pt, normal_t)
                 if is_inside:
                     # dontstop = False
                     cell_prop.append(key)
@@ -77,15 +79,42 @@ def find_cell(self, points, nb_pt, normal_t=None):
 
                 # inode = inode + 1
                 # break
-            if len(cell_prop) > 2:
+
+            # if no cell was found, give it a second try
+            # TODO first check if outside mesh
+            if len(cell_prop) == 0:
+                # test all cells (sorted by center, i.e. mean of vertices)
+                vert_cent = (
+                    point_coord[connect[:, 0]]
+                    + point_coord[connect[:, 1]]
+                    + point_coord[connect[:, 2]]
+                ) / 3
+                dist_vert_cent = np.reshape(
+                    np.sqrt(
+                        (vert_cent[:, 0] - pt[0]) ** 2 + (vert_cent[:, 1] - pt[1]) ** 2
+                    ),
+                    (cells.nb_cell, 1),
+                )
+                Imin_vert_cent = np.argsort(dist_vert_cent, axis=0)[:, 0]
+                i = 0
+                is_inside = False
+                while i < cells.nb_cell and not is_inside:
+                    vert = self.get_vertice(Imin_vert_cent[i])[key]
+                    (is_inside, a, b) = ref_cell.is_inside(vert, pt, normal_t)
+                    if is_inside:
+                        # dontstop = False
+                        cell_prop = [key, Imin_vert_cent[i]]
+                    i += 1
+
+            # No cell contain the point atleast (only possible if point is outside mesh)
+            if len(cell_prop) == 0:
+                cells_list.append(None)
+            # one cell found
+            elif len(cell_prop) == 2:
+                cells_list.append(cell_prop)
+            # more than one cells found
+            elif len(cell_prop) > 2:
                 ind = np.where(np.min(a) == a)[0][0]
                 cells_list.append(cell_prop[2 * ind : 2 * ind + 2])
-            else:
-                if not cell_prop:
-                    cells_list.append(None)
-                else:
-                    cells_list.append(cell_prop)
-
-            # No cell contain the point
 
     return cells_list

--- a/pyleecan/Methods/Mesh/RefCell/interpolation.py
+++ b/pyleecan/Methods/Mesh/RefCell/interpolation.py
@@ -26,8 +26,8 @@ def interpolation(self, point, vertice, field):
 
     """
 
-    point_ref = self.get_ref_point(vertice, point)
-    [values_ref, size] = self.shape_function(point_ref, 1)
+    point_ref = self.get_ref_point(vertice, point) # TODO: input only single point
+    [values_ref, size] = self.shape_function(point_ref) # TODO: input only multipel points
 
     interp_func = np.tensordot(values_ref, field, axes=([2], [0]))
 

--- a/pyleecan/Methods/Mesh/RefTriangle3/grad_shape_function.py
+++ b/pyleecan/Methods/Mesh/RefTriangle3/grad_shape_function.py
@@ -7,7 +7,7 @@ def grad_shape_function(self, point):
     """ Return the gradient of linear shape functions in reference triangle for a given point """
 
     values = np.zeros([2, 3], dtype=float)
-    [x, y] = point[0:2]
+    (x, y) = point[0:2]
 
     if (x >= 0) or (y >= 0) or (1 - x - y >= 0):
         values[0, 0] = -1

--- a/pyleecan/Methods/Mesh/RefTriangle3/is_inside.py
+++ b/pyleecan/Methods/Mesh/RefTriangle3/is_inside.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+
+def is_inside(self, vertice, point, normal_t=None):
+
+    point_ref = self.get_ref_point(vertice, point)
+    s = point_ref[0]
+    t = point_ref[1]
+    a = s
+    b = t
+    c = 1 - s - t
+    is_inside = (a > -self.epsilon) & (b > -self.epsilon) & (c > -self.epsilon)
+
+    # Optional : Check that normals are almost aligned
+    if normal_t is not None:
+        normal_s = self.get_normal(vertice)
+        scal_st = np.dot(normal_t[0:2], normal_s)
+        is_colinear = abs(scal_st) > 1 - 2 * self.epsilon
+        is_inside = is_inside & is_colinear
+
+    return is_inside, a, b

--- a/pyleecan/Methods/Mesh/SolutionVector/get_field.py
+++ b/pyleecan/Methods/Mesh/SolutionVector/get_field.py
@@ -42,6 +42,7 @@ def get_field(self, args=None):
         )
     else:
         for comp in self.field.components:
+            along_arg = list()
             for axis in self.field.components[comp].axes:
                 if axis.name in args:
                     if isinstance(args[axis.name], int):

--- a/pyleecan/Methods/Simulation/MagFEMM/get_meshsolution.py
+++ b/pyleecan/Methods/Simulation/MagFEMM/get_meshsolution.py
@@ -5,6 +5,8 @@ from ....definitions import MAIN_DIR
 from ....Classes.MeshMat import MeshMat
 from ....Classes.CellMat import CellMat
 from ....Classes.PointMat import PointMat
+from ....Classes.RefTriangle3 import RefTriangle3
+
 from os.path import join
 
 from ....Functions.FEMM import (
@@ -117,6 +119,7 @@ def get_meshsolution(self, femm, save_path, j_t0):
             nb_pt_per_cell=3,
             indice=np.linspace(0, NbElem - 1, NbElem, dtype=int),
         )
+        mesh.cell["triangle"].interpolation.ref_cell = RefTriangle3(epsilon=1e-9)
         mesh.point = PointMat(
             coordinate=listNd[:, 0:2], nb_pt=NbNd, indice=np.linspace(0, NbNd - 1, NbNd)
         )


### PR DESCRIPTION
This PR propose an extended search for find_cell method (get the cell that contains a given point) of MeshMat. 

With the actual implementation there were cases, were no cell (of type triangle) was found, e.g. with the following values:
```
# Triangle 
(x1, y1) = 0, 0.5
(x2, y2) = 1, 0.1
(x3, y3) = -1, 0.1
# Point
(x, y) = 0, 0
```
Although the point is nearest to node 1, no cell is found, since only cells that contain node 1 were searched.
Now, after a failed first search, all other cells are tested if they contain the point (ordered by their cell center).