### PR TITLE
enable SCIM simulation with rotor currents

### DIFF
--- a/Tests/Functions/test_gmsh.py
+++ b/Tests/Functions/test_gmsh.py
@@ -13,6 +13,7 @@ from Tests import save_validation_path as save_path
 
 
 @pytest.mark.GMSH
+@pytest.mark.long
 def test_slot_10():
     """Check generation of the 3D mesh of Slot 10 with gmsh"""
     if isinstance(gen_3D_mesh, ImportError):

--- a/Tests/Methods/Slot/test_SlotW10_meth.py
+++ b/Tests/Methods/Slot/test_SlotW10_meth.py
@@ -217,7 +217,7 @@ class Test_SloyW10_meth(object):
         point_ref = (Z7 + Ztan1 + Ztan2 + Z6) / 4
 
         surface = SurfLine(
-            line_list=curve_list, point_ref=point_ref, label="WindS_R0_T0_S0"
+            line_list=curve_list, point_ref=point_ref, label="Wind_Stator_R0_T0_S0"
         )
         expected.append(surface)
 
@@ -229,7 +229,7 @@ class Test_SloyW10_meth(object):
         curve_list.append(Segment(Ztan2, Ztan1))
         point_ref = (Z4 + Ztan1 + Ztan2 + Z5) / 4
         surface = SurfLine(
-            line_list=curve_list, point_ref=point_ref, label="WindS_R0_T1_S0"
+            line_list=curve_list, point_ref=point_ref, label="Wind_Stator_R0_T1_S0"
         )
         expected.append(surface)
 

--- a/Tests/Methods/Slot/test_SlotW21_meth.py
+++ b/Tests/Methods/Slot/test_SlotW21_meth.py
@@ -209,7 +209,7 @@ class Test_SlowW21_meth(object):
         curve_list.append(Segment(Z4, Z3))
         point_ref = (Z3 + Ztan1 + Ztan2 + Z4) / 4
         surface = SurfLine(
-            line_list=curve_list, point_ref=point_ref, label="WindS_R0_T0_S0"
+            line_list=curve_list, point_ref=point_ref, label="Wind_Stator_R0_T0_S0"
         )
         expected.append(surface)
 
@@ -221,7 +221,7 @@ class Test_SlowW21_meth(object):
         curve_list.append(Segment(Ztan2, Ztan1))
         point_ref = (Z5 + Ztan1 + Ztan2 + Z6) / 4
         surface = SurfLine(
-            line_list=curve_list, point_ref=point_ref, label="WindS_R0_T1_S0"
+            line_list=curve_list, point_ref=point_ref, label="Wind_Stator_R0_T1_S0"
         )
         expected.append(surface)
 

--- a/Tests/Plot/test_ICEM_2020.py
+++ b/Tests/Plot/test_ICEM_2020.py
@@ -90,6 +90,7 @@ def test_FEMM_sym():
 
 
 @pytest.mark.GMSH
+@pytest.mark.long
 def test_gmsh_mesh_dict():
     """Figure 10: Generate a 3D mesh with Gmsh by setting the
     number of element on each lines
@@ -149,8 +150,10 @@ def test_gmsh_mesh_dict():
 
 
 @pytest.mark.GMSH
+@pytest.mark.long
 def test_SlotMulti_sym():
-    """Figure 11: Generate a 3D mesh with GMSH for a lamination
+    """Figure 11: Genera
+    te a 3D mesh with GMSH for a lamination
     with several slot types and notches
     """
 

--- a/pyleecan/Classes/Class_Dict.json
+++ b/pyleecan/Classes/Class_Dict.json
@@ -3573,7 +3573,8 @@
             "comp_length_ring",
             "plot",
             "comp_number_phase_eq",
-            "comp_periodicity"
+            "comp_periodicity",
+            "comp_surface_ring"
         ],
         "mother": "LamSlotWind",
         "name": "LamSquirrelCage",

--- a/pyleecan/Classes/Class_Dict.json
+++ b/pyleecan/Classes/Class_Dict.json
@@ -7560,7 +7560,8 @@
             "get_surface_tooth",
             "is_outwards",
             "plot",
-            "comp_width_opening"
+            "comp_width_opening",
+            "get_name_lam"
         ],
         "mother": "",
         "name": "Slot",

--- a/pyleecan/Classes/LamSquirrelCage.py
+++ b/pyleecan/Classes/LamSquirrelCage.py
@@ -48,6 +48,11 @@ try:
 except ImportError as error:
     comp_periodicity = error
 
+try:
+    from ..Methods.Machine.LamSquirrelCage.comp_surface_ring import comp_surface_ring
+except ImportError as error:
+    comp_surface_ring = error
+
 
 from ._check import InitUnKnowClassError
 from .Material import Material
@@ -129,6 +134,18 @@ class LamSquirrelCage(LamSlotWind):
         )
     else:
         comp_periodicity = comp_periodicity
+    # cf Methods.Machine.LamSquirrelCage.comp_surface_ring
+    if isinstance(comp_surface_ring, ImportError):
+        comp_surface_ring = property(
+            fget=lambda x: raise_(
+                ImportError(
+                    "Can't use LamSquirrelCage method comp_surface_ring: "
+                    + str(comp_surface_ring)
+                )
+            )
+        )
+    else:
+        comp_surface_ring = comp_surface_ring
     # save and copy methods are available in all object
     save = save
     copy = copy

--- a/pyleecan/Classes/Slot.py
+++ b/pyleecan/Classes/Slot.py
@@ -76,6 +76,11 @@ try:
 except ImportError as error:
     comp_width_opening = error
 
+try:
+    from ..Methods.Slot.Slot.get_name_lam import get_name_lam
+except ImportError as error:
+    get_name_lam = error
+
 
 from ._check import InitUnKnowClassError
 
@@ -207,6 +212,15 @@ class Slot(FrozenClass):
         )
     else:
         comp_width_opening = comp_width_opening
+    # cf Methods.Slot.Slot.get_name_lam
+    if isinstance(get_name_lam, ImportError):
+        get_name_lam = property(
+            fget=lambda x: raise_(
+                ImportError("Can't use Slot method get_name_lam: " + str(get_name_lam))
+            )
+        )
+    else:
+        get_name_lam = get_name_lam
     # save and copy methods are available in all object
     save = save
     copy = copy

--- a/pyleecan/Functions/FEMM/assign_FEMM_surface.py
+++ b/pyleecan/Functions/FEMM/assign_FEMM_surface.py
@@ -50,11 +50,11 @@ def assign_FEMM_surface(femm, surf, prop, FEMM_dict, rotor, stator):
         femm.mi_selectlabel(point_ref.real, point_ref.imag)
 
         # Get circuit or magnetization properties if needed
-        if "Wind" in label:  # If the surface is a winding
+        if "Wind" in label or "Bar":  # If the surface is a winding
             if "Rotor" in label:  # Winding on the rotor
-                Clabel = "Circr" + prop[2]
+                Clabel = "Circr" + prop[:-1][2:]
             else:  # winding on the stator
-                Clabel = "Circs" + prop[2]
+                Clabel = "Circs" + prop[:-1][2:]
             Ntcoil = lam.winding.Ntcoil
             if prop[-1] == "-":  # Adapt Ntcoil sign if needed
                 Ntcoil *= -1

--- a/pyleecan/Functions/FEMM/create_FEMM_circuit.py
+++ b/pyleecan/Functions/FEMM/create_FEMM_circuit.py
@@ -2,7 +2,7 @@
 
 from numpy import linalg as LA, pi, sign, sqrt
 
-
+# TODO: function seems to be unused, remove ?
 def create_FEMM_circuit(femm, label, is_eddies, lam, I, is_mmf, j_t0, materials):
     """Set in FEMM circuits property
 

--- a/pyleecan/Functions/FEMM/create_FEMM_circuit_material.py
+++ b/pyleecan/Functions/FEMM/create_FEMM_circuit_material.py
@@ -52,9 +52,9 @@ def create_FEMM_circuit_material(
 
     # Decode the label
     st = label.split("_")
-    Nrad_id = int(st[1][1:])  # zone radial coordinate
-    Ntan_id = int(st[2][1:])  # zone tangential coordinate
-    Zs_id = int(st[3][1:])  # Zone slot number coordinate
+    Nrad_id = int(st[2][1:])  # zone radial coordinate
+    Ntan_id = int(st[3][1:])  # zone tangential coordinate
+    Zs_id = int(st[4][1:])  # Zone slot number coordinate
     # Get the phase value in the correct slot zone
     q_id = get_phase_id(wind_mat, Nrad_id, Ntan_id, Zs_id)
     s = sign(wind_mat[Nrad_id, Ntan_id, Zs_id, q_id])

--- a/pyleecan/Functions/FEMM/create_FEMM_materials.py
+++ b/pyleecan/Functions/FEMM/create_FEMM_materials.py
@@ -114,19 +114,12 @@ def create_FEMM_materials(
                 femm.mi_addmaterial("Air", 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0)
                 materials.append("Air")
             prop_dict[label] = "Air"
-        elif "BarR" in label:  # Squirrel cage
-            prop, materials = create_FEMM_bar(
-                femm, is_mmfr, rotor.mat_type.elec.rho, materials
-            )
-            prop_dict[label] = prop
-        elif "WindR" in label:  # Rotor Winding
+        elif "Wind" in label or "Bar" in label:
+            I = Is if "Stator" in label else Ir
+            is_mmf = is_mmfs if "Stator" in label else is_mmfr
+            lam = stator if "Stator" in label else rotor
             prop, materials, circuits = create_FEMM_circuit_material(
-                femm, circuits, label, is_eddies, rotor, Ir, is_mmfr, j_t0, materials
-            )
-            prop_dict[label] = prop
-        elif "WindS" in label:  # Stator Winding
-            prop, materials, circuits = create_FEMM_circuit_material(
-                femm, circuits, label, is_eddies, stator, Is, is_mmfs, j_t0, materials
+                femm, circuits, label, is_eddies, lam, I, is_mmf, j_t0, materials
             )
             prop_dict[label] = prop
         elif "Magnet" in label and "Rotor" in label:  # Rotor Magnet

--- a/pyleecan/Functions/FEMM/set_FEMM_circuit_prop.py
+++ b/pyleecan/Functions/FEMM/set_FEMM_circuit_prop.py
@@ -35,13 +35,15 @@ def set_FEMM_circuit_prop(femm, circuits, Clabel, I, is_mmf, Npcpp, j_t0):
     q_id = int(Clabel[5:])
     if I is not None:
         I = I.values
-    if Clabel in circuits:
-        if I is not None and I.size != 0 and LA.norm(I) != 0:
-            # Update existing circuit
-            femm.mi_modifycircprop(Clabel, 1, is_mmf * I[q_id, j_t0] / Npcpp)
-    else:
+    if Clabel not in circuits:
         # Create new circuit
         femm.mi_addcircprop(Clabel, 0, 1)
         circuits.append(Clabel)
+
+    # Update circuit
+    if I is not None and I.size != 0 and LA.norm(I) != 0:
+        femm.mi_modifycircprop(Clabel, 1, is_mmf * I[q_id, j_t0] / Npcpp)
+    else:
+        femm.mi_modifycircprop(Clabel, 1, 0)
 
     return circuits

--- a/pyleecan/Functions/Winding/find_wind_phase_color.py
+++ b/pyleecan/Functions/Winding/find_wind_phase_color.py
@@ -22,9 +22,9 @@ def find_wind_phase_color(label, wind_mat):
 
     """
     st = label.split("_")
-    Nrad = int(st[1][1:])
-    Ntan = int(st[2][1:])
-    Zs = int(st[3][1:])
+    Nrad = int(st[2][1:])
+    Ntan = int(st[3][1:])
+    Zs = int(st[4][1:])
     if wind_mat is not None:
         q = get_phase_id(wind_mat, Nrad, Ntan, Zs)
         if q is None:  # No phase => White

--- a/pyleecan/Generator/ClassesRef/Machine/LamSquirrelCage.csv
+++ b/pyleecan/Generator/ClassesRef/Machine/LamSquirrelCage.csv
@@ -5,3 +5,4 @@ ring_mat,,Material of the Rotor short circuit ring,,Material,,,,,,,comp_length_r
 ,,,,,,,,,,,plot,,,
 ,,,,,,,,,,,comp_number_phase_eq,,,
 ,,,,,,,,,,,comp_periodicity,,,
+,,,,,,,,,,,comp_surface_ring,,,

--- a/pyleecan/Generator/ClassesRef/Slot/Slot.csv
+++ b/pyleecan/Generator/ClassesRef/Slot/Slot.csv
@@ -11,3 +11,4 @@ Zs,-,slot number,0,int,36,0,1000,,Slot,,build_geometry_half_tooth,VERSION,1,Gene
 ,,,,,,,,,,,is_outwards,,,
 ,,,,,,,,,,,plot,,,
 ,,,,,,,,,,,comp_width_opening,,,
+,,,,,,,,,,,get_name_lam,,,

--- a/pyleecan/Methods/Machine/LamSquirrelCage/comp_surface_ring.py
+++ b/pyleecan/Methods/Machine/LamSquirrelCage/comp_surface_ring.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+
 def comp_surface_ring(self):
     """Computation of the ring cross-section surface area
 

--- a/pyleecan/Methods/Machine/WindingSC/comp_connection_mat.py
+++ b/pyleecan/Methods/Machine/WindingSC/comp_connection_mat.py
@@ -6,7 +6,8 @@ from ....Methods.Machine.Winding import WindingError
 from ....Functions.Winding.reverse_wind_mat import reverse_wind_mat
 from ....Functions.Winding.shift_wind_mat import shift_wind_mat
 
-
+# TODO: update docstring -> there should not be elementary circuits since
+#       every bar could have its own unique current
 def comp_connection_mat(self, Zs=None):
     """Compute the Winding Matrix (for winding type 10)
     type 10 : Squirrel cage Winding (elementary circuit loop involving bar n°1
@@ -55,8 +56,9 @@ def comp_connection_mat(self, Zs=None):
 
     for ii in range(Zs):
         # phase n°ii
-        wind_mat[0, 0, ii, ii] = -1
-        wind_mat[0, 0, (ii - 1) % Zs, ii] = 1
+        # wind_mat[0, 0, ii, ii] = -1 # there are only positive 'windings' for now
+        # wind_mat[0, 0, (ii - 1) % Zs, ii] = 1
+        wind_mat[0, 0, ii, ii] = 1
 
     # Apply the transformations
     if self.is_reverse_wind:

--- a/pyleecan/Methods/Slot/HoleM57/build_geometry.py
+++ b/pyleecan/Methods/Slot/HoleM57/build_geometry.py
@@ -32,9 +32,9 @@ def build_geometry(self, alpha=0, delta=0, is_simplified=False):
     """
 
     if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
+        st = "_Stator"
     else:
-        st = "R"
+        st = "_Rotor"
     Rbo = self.get_Rbo()
 
     # "Tooth" angle (P1',0,P1)
@@ -122,7 +122,9 @@ def build_geometry(self, alpha=0, delta=0, is_simplified=False):
     curve_list = set_name_line(curve_list, "magnet_1_line")
     point_ref = (Z2 + Z3 + Z6 + Z7) / 4
     S2 = SurfLine(
-        line_list=curve_list, label="Magnet" + st + "_N_R0_T0_S0", point_ref=point_ref,
+        line_list=curve_list,
+        label="Magnet" + st + "_N_R0_T0_S0",
+        point_ref=point_ref,
     )
 
     # Air surface with magnet_0 and W1 > 0
@@ -166,7 +168,9 @@ def build_geometry(self, alpha=0, delta=0, is_simplified=False):
     # initiating the label of the line on the magnet surface
     curve_list = set_name_line(curve_list, "magnet_2_line")
     S5 = SurfLine(
-        line_list=curve_list, label="Magnet" + st + "_N_R0_T1_S0", point_ref=point_ref,
+        line_list=curve_list,
+        label="Magnet" + st + "_N_R0_T1_S0",
+        point_ref=point_ref,
     )
 
     # Air surface with magnet_1 and W1 > 0

--- a/pyleecan/Methods/Slot/Slot/get_name_lam.py
+++ b/pyleecan/Methods/Slot/Slot/get_name_lam.py
@@ -1,0 +1,26 @@
+from ....Methods import ParentMissingError
+
+
+def get_name_lam(self):
+    """Return the name of the parent lamination
+
+    Parameters
+    ----------
+    self : Slot
+        A Slot object
+
+    Returns
+    -------
+    name: string
+        The name of the parent lamination
+
+    """
+
+    if self.parent is not None:
+        if self.get_is_stator():
+            name = "Stator"
+        else:
+            name = "Rotor"
+        return name
+    else:
+        raise ParentMissingError("Error: The slot is not inside a Lamination")

--- a/pyleecan/Methods/Slot/SlotCirc/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotCirc/get_surface_wind.py
@@ -24,11 +24,8 @@ def get_surface_wind(self, alpha=0, delta=0):
     surf_wind: Surface
         Surface corresponding to the Winding Area
     """
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Compute point
     Rbo = self.get_Rbo()
@@ -52,7 +49,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     curve_list.append(Arc1(begin=Z2, end=Z1, radius=-Rbo, is_trigo_direction=False))
     surf = SurfLine(
         line_list=curve_list,
-        label="Wind" + st + "_R0_T0_S0",
+        label="Wind_" + st + "_R0_T0_S0",
         point_ref=(Ztan1 + Ztan2) / 2,
     )
 

--- a/pyleecan/Methods/Slot/SlotW10/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW10/build_geometry_wind.py
@@ -30,10 +30,9 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
         List of surface delimiting the winding zone
 
     """
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
+
     [Z10, Z9, Z8, Z7, Z6, Z5, Z4, Z3, Z2, Z1] = self._comp_point_coordinate()
     X = linspace(Z7, Z6, Nrad + 1)
     # Nrad+1 and Ntan+1 because 3 points => 2 zones
@@ -66,7 +65,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Segment(Z3, Z4))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)
@@ -78,7 +77,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z4, Z1))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW10/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW10/get_surface_wind.py
@@ -24,11 +24,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[3:-3]
@@ -44,7 +41,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW11/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW11/get_surface_wind.py
@@ -27,11 +27,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[2:-2]
@@ -47,7 +44,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW12/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW12/get_surface_wind.py
@@ -25,11 +25,8 @@ def get_surface_wind(self, alpha=0, delta=0):
     surf_wind: Surface
         Surface corresponding to the Winding Area
     """
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     if self.is_outwards():
         Zmid = self.get_Rbo() + self.H0 + 2 * self.R1 + self.H1
@@ -45,7 +42,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     )
 
     surface = SurfLine(
-        line_list=line_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=line_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW13/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW13/build_geometry_wind.py
@@ -30,10 +30,9 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
         List of surface delimiting the winding zone
 
     """
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
+
     [Z10, Z9, Z8, Z7, Z6, Z5, Z4, Z3, Z2, Z1] = self._comp_point_coordinate()
 
     X = linspace(Z7, Z6, Nrad + 1)
@@ -66,7 +65,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Segment(Z[ii + 1][jj + 1], Z[ii + 1][jj]))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )  # surface in the winding area
                 surf_list.append(surface)
@@ -78,7 +77,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z[ii + 1][jj], Z[ii][jj]))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )  # surface in the winding area
                 surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW13/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW13/get_surface_wind.py
@@ -24,11 +24,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[3:-3]
@@ -44,7 +41,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW14/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW14/get_surface_wind.py
@@ -24,11 +24,8 @@ def get_surface_wind(self, alpha=0, delta=0):
     surf_wind: Surface
         Surface corresponding to the Winding Area
     """
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[2:-2]
@@ -42,7 +39,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - self.H1 - self.H3 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW15/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW15/get_surface_wind.py
@@ -25,11 +25,8 @@ def get_surface_wind(self, alpha=0, delta=0):
     surf_wind: Surface
         Surface corresponding to the Winding Area
     """
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[1:-1]
@@ -43,7 +40,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - self.H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW16/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW16/get_surface_wind.py
@@ -26,11 +26,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[1:-1]
@@ -46,7 +43,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     # Create surface
     Zmid = self.get_Rbo() - self.H0 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW21/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW21/build_geometry_wind.py
@@ -31,10 +31,9 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
 
     """
 
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
+
     [Z8, Z7, Z6, Z5, Z4, Z3, Z2, Z1] = self._comp_point_coordinate()
     X = linspace(Z6, Z5, Nrad + 1)
 
@@ -66,7 +65,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Segment(Z[ii + 1][jj + 1], Z[ii + 1][jj]))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)
@@ -79,7 +78,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z[ii + 1][jj], Z[ii][jj]))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW21/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW21/get_surface_wind.py
@@ -20,16 +20,16 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[2:-2]
     curve_list.append(
-        Segment(begin=curve_list[-1].get_end(), end=curve_list[0].get_begin(),)
+        Segment(
+            begin=curve_list[-1].get_end(),
+            end=curve_list[0].get_begin(),
+        )
     )
 
     # Create surface
@@ -40,7 +40,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW22/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW22/build_geometry_wind.py
@@ -32,10 +32,8 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
 
     """
 
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     Rbo = self.get_Rbo()
 
@@ -85,7 +83,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Arc1(Z3, Z4, -abs(Z3), is_trigo_direction=False))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)
@@ -97,7 +95,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z4, Z1))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW23/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW23/build_geometry_wind.py
@@ -32,10 +32,8 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
 
     """
 
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     [Z8, Z7, Z6, Z5, Z4, Z3, Z2, Z1] = self._comp_point_coordinate()
     X = linspace(Z6, Z5, Nrad + 1)
@@ -76,7 +74,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Segment(Z3, Z4))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)
@@ -91,7 +89,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z4, Z1))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW23/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW23/get_surface_wind.py
@@ -20,11 +20,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[2:-2]
@@ -41,7 +38,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - self.H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW24/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW24/build_geometry_wind.py
@@ -32,10 +32,9 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
 
     """
 
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
+
     [Z4, Z3, Z2, Z1] = self._comp_point_coordinate()
 
     X = linspace(Z4, Z3, Nrad + 1)
@@ -72,7 +71,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Arc1(Z3, Z4, -abs(Z3), is_trigo_direction=False))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
             else:
@@ -83,7 +82,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z4, Z1))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
             surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW24/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW24/get_surface_wind.py
@@ -20,11 +20,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()
@@ -43,7 +40,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW25/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW25/build_geometry_wind.py
@@ -31,10 +31,9 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
         List of surface delimiting the winding zone
 
     """
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
+
     [Z8, Z7, Z6, Z5, Z4, Z3, Z2, Z1] = self._comp_point_coordinate()
     X = linspace(Z3, Z4, Nrad + 1)
 
@@ -73,7 +72,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Arc1(Z3, Z4, -abs(Z3), is_trigo_direction=False))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)
@@ -85,7 +84,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z4, Z1))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW25/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW25/get_surface_wind.py
@@ -22,11 +22,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[1:-1]
@@ -45,7 +42,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW26/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW26/get_surface_wind.py
@@ -24,11 +24,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[1:-1]
@@ -42,7 +39,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.R1 - self.H1 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW27/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW27/get_surface_wind.py
@@ -24,11 +24,8 @@ def get_surface_wind(self, alpha=0, delta=0):
     surf_wind: Surface
         Surface corresponding to the Winding Area
     """
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[1:-1]
@@ -42,7 +39,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - self.H1
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW28/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW28/get_surface_wind.py
@@ -26,11 +26,8 @@ def get_surface_wind(self, alpha=0, delta=0):
     surf_wind: Surface
         Surface corresponding to the Winding Area
     """
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[1:-1]
@@ -44,7 +41,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - self.R1 - self.H3 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW29/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW29/build_geometry_wind.py
@@ -30,10 +30,9 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
 
     """
 
-    if self.get_is_stator():  # check if the slot is on the stator
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
+
     [Z12, Z11, Z10, Z9, Z8, Z7, Z6, Z5, Z4, Z3, Z2, Z1] = self._comp_point_coordinate()
 
     X = linspace(Z8, Z7, Nrad + 1)
@@ -73,7 +72,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                     curve_list.append(Segment(Z2, Z3))
                 if ii != Nrad - 1:
                     curve_list.append(Segment(Z3, Z4))
-                label = "Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0"
+                label = "Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0"
                 surface = SurfLine(
                     line_list=curve_list, label=label, point_ref=point_ref
                 )
@@ -86,7 +85,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
                 curve_list.append(Segment(Z4, Z1))
                 surface = SurfLine(
                     line_list=curve_list,
-                    label="Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
+                    label="Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0",
                     point_ref=point_ref,
                 )
                 surf_list.append(surface)

--- a/pyleecan/Methods/Slot/SlotW29/get_surface_wind.py
+++ b/pyleecan/Methods/Slot/SlotW29/get_surface_wind.py
@@ -20,11 +20,8 @@ def get_surface_wind(self, alpha=0, delta=0):
         Surface corresponding to the Winding Area
     """
 
-    # check if the slot is on the stator
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     # Create curve list
     curve_list = self.build_geometry()[3:-3]
@@ -38,7 +35,7 @@ def get_surface_wind(self, alpha=0, delta=0):
     else:
         Zmid = self.get_Rbo() - self.H0 - self.H1 - self.H2 / 2
     surface = SurfLine(
-        line_list=curve_list, label="Wind" + st + "_R0_T0_S0", point_ref=Zmid
+        line_list=curve_list, label="Wind_" + st + "_R0_T0_S0", point_ref=Zmid
     )
 
     # Apply transformation

--- a/pyleecan/Methods/Slot/SlotW60/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW60/build_geometry_wind.py
@@ -43,11 +43,8 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
         )
     self.check()
 
-    # check if the slot is on the stator for the label
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     [Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11] = self._comp_point_coordinate()
 
@@ -87,10 +84,10 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
         wind2.append(Segment(Zw2s, Zw3s))
 
     surf_list.append(
-        SurfLine(line_list=wind1, label="Wind" + st + "_R0_T0_S0", point_ref=Ref1)
+        SurfLine(line_list=wind1, label="Wind_" + st + "_R0_T0_S0", point_ref=Ref1)
     )
     surf_list.append(
-        SurfLine(line_list=wind2, label="Wind" + st + "_R0_T1_S0", point_ref=Ref2)
+        SurfLine(line_list=wind2, label="Wind_" + st + "_R0_T1_S0", point_ref=Ref2)
     )
 
     # Rotate and translate the surfaces

--- a/pyleecan/Methods/Slot/SlotW61/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW61/build_geometry_wind.py
@@ -38,11 +38,8 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
         )
     self.check()
 
-    # check if the slot is on the stator for the label
-    if self.get_is_stator():
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     [Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10] = self._comp_point_coordinate()
 

--- a/pyleecan/Methods/Slot/SlotW61/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotW61/build_geometry_wind.py
@@ -79,10 +79,10 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
         wind2.append(Segment(Zw2s, Zw3s))
 
     surf_list.append(
-        SurfLine(line_list=wind1, label="Wind" + st + "_R0_T0_S0", point_ref=Ref1)
+        SurfLine(line_list=wind1, label="Wind_" + st + "_R0_T0_S0", point_ref=Ref1)
     )
     surf_list.append(
-        SurfLine(line_list=wind2, label="Wind" + st + "_R0_T1_S0", point_ref=Ref2)
+        SurfLine(line_list=wind2, label="Wind_" + st + "_R0_T1_S0", point_ref=Ref2)
     )
 
     # Rotate and translate the surfaces

--- a/pyleecan/Methods/Slot/SlotWind/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotWind/build_geometry_wind.py
@@ -89,7 +89,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
             surf_list.append(surf.copy())
 
     # Set all label
-    set_label(surf_list, Nrad, Ntan, self.get_is_stator())
+    set_label(surf_list, Nrad, Ntan, self.get_name_lam())
 
     # Apply transformation
     for surf in surf_list:
@@ -99,12 +99,9 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
     return surf_list
 
 
-def set_label(surf_list, Nrad, Ntan, is_stator):
+def set_label(surf_list, Nrad, Ntan, st):
     """Set the normalized label"""
-
-    # get the name of the lamination
-    st = self.get_name_lam()
-
+    
     index = 0
     for ii in range(Nrad):
         for jj in range(Ntan):

--- a/pyleecan/Methods/Slot/SlotWind/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotWind/build_geometry_wind.py
@@ -102,15 +102,13 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
 def set_label(surf_list, Nrad, Ntan, is_stator):
     """Set the normalized label"""
 
-    if is_stator:
-        st = "S"
-    else:
-        st = "R"
+    # get the name of the lamination
+    st = self.get_name_lam()
 
     index = 0
     for ii in range(Nrad):
         for jj in range(Ntan):
             surf_list[index].label = (
-                "Wind" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0"
+                "Wind_" + st + "_R" + str(ii) + "_T" + str(jj) + "_S0"
             )
             index += 1

--- a/pyleecan/Methods/Slot/SlotWind/build_geometry_wind.py
+++ b/pyleecan/Methods/Slot/SlotWind/build_geometry_wind.py
@@ -101,7 +101,7 @@ def build_geometry_wind(self, Nrad, Ntan, is_simplified=False, alpha=0, delta=0)
 
 def set_label(surf_list, Nrad, Ntan, st):
     """Set the normalized label"""
-    
+
     index = 0
     for ii in range(Nrad):
         for jj in range(Ntan):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ meshio>=4.0.15
 h5py>=2.10.0
 nbformat
 nbconvert
+quadpy


### PR DESCRIPTION
This PR mainly enables simulation of SCIM (LamSquirrelCage rotors) with rotor currents.
The rotor bars now have only positive winding direction, with one phase each bar.

There are also some bug fixes and code optimizations included.
At most the names/labels of the surfaces of the windings are unified to contain 'Stator' or 'Rotor' instead 'S' or 'R' by the introduction of the Slot class method get_name_lam. This also enables to easily change the names e.g. to 'Lam_x' later on (with MachineUD).