### PR TITLE
[BC] number of phases was missing in the n2dq transformation

### DIFF
--- a/pyleecan/Methods/Simulation/InputCurrent/gen_input.py
+++ b/pyleecan/Methods/Simulation/InputCurrent/gen_input.py
@@ -82,6 +82,7 @@ def gen_input(self):
             Idq = n2dq(
                 transpose(output.Is.values),
                 2 * pi * output.felec * output.Time.get_values(is_oneperiod=False),
+                n=qs,
                 is_dq_rms=True,
             )
             output.Id_ref = mean(Idq[:, 0])


### PR DESCRIPTION
There was a bug when the machine has more than 3 phases in the n2dq transformation, an error because the matrices shape did not match. Only the parameter 'n' was missing in the function call. 