### PR TITLE
None correct

### DIFF
--- a/Tests/GUI/DMachineSetup/test_SMachineType.py
+++ b/Tests/GUI/DMachineSetup/test_SMachineType.py
@@ -346,6 +346,20 @@ class TestSMachineType(object):
         assert setup["widget"].machine.stator.winding.type_connection == None
         assert setup["widget"].machine.stator.winding.Lewout == None
 
+    @pytest.mark.skip(reason="Need to have DMachineSetup as parent")
+    def test_set_type_ipmsm(self, setup):
+        """Check that you can define an IPMSM machine"""
+        setup["widget"].c_type.setCurrentText("IPMSM")
+        # Clear the field before writing the new value
+        setup["widget"].si_p.clear()
+        value = int(uniform(3, 100))
+        QTest.keyClicks(setup["widget"].si_p, str(value))
+        setup["widget"].si_p.editingFinished.emit()  # To trigger the slot
+
+        assert setup["widget"].machine.stator.winding.p == value
+        assert type(setup["widget"].machine) is MachineIPMSM
+        assert setup["widget"].machine.rotor.hole == list()
+
     # def test_set_c_type(self, setup):
     #     """Check that the Widget allow to update c_type when changing value in the combobox"""
     #     # SIPMSM

--- a/pyleecan/Classes/Arc1.py
+++ b/pyleecan/Classes/Arc1.py
@@ -297,10 +297,14 @@ class Arc1(Arc):
         Arc1_dict = super(Arc1, self).as_dict()
         if self.begin is None:
             Arc1_dict["begin"] = None
+        elif isinstance(self.begin, float):
+            Arc1_dict["begin"] = self.begin
         else:
             Arc1_dict["begin"] = str(self.begin)
         if self.end is None:
             Arc1_dict["end"] = None
+        elif isinstance(self.end, float):
+            Arc1_dict["end"] = self.end
         else:
             Arc1_dict["end"] = str(self.end)
         Arc1_dict["radius"] = self.radius

--- a/pyleecan/Classes/Arc2.py
+++ b/pyleecan/Classes/Arc2.py
@@ -290,10 +290,14 @@ class Arc2(Arc):
         Arc2_dict = super(Arc2, self).as_dict()
         if self.begin is None:
             Arc2_dict["begin"] = None
+        elif isinstance(self.begin, float):
+            Arc2_dict["begin"] = self.begin
         else:
             Arc2_dict["begin"] = str(self.begin)
         if self.center is None:
             Arc2_dict["center"] = None
+        elif isinstance(self.center, float):
+            Arc2_dict["center"] = self.center
         else:
             Arc2_dict["center"] = str(self.center)
         Arc2_dict["angle"] = self.angle

--- a/pyleecan/Classes/Arc3.py
+++ b/pyleecan/Classes/Arc3.py
@@ -290,10 +290,14 @@ class Arc3(Arc):
         Arc3_dict = super(Arc3, self).as_dict()
         if self.begin is None:
             Arc3_dict["begin"] = None
+        elif isinstance(self.begin, float):
+            Arc3_dict["begin"] = self.begin
         else:
             Arc3_dict["begin"] = str(self.begin)
         if self.end is None:
             Arc3_dict["end"] = None
+        elif isinstance(self.end, float):
+            Arc3_dict["end"] = self.end
         else:
             Arc3_dict["end"] = str(self.end)
         Arc3_dict["is_trigo_direction"] = self.is_trigo_direction

--- a/pyleecan/Classes/Circle.py
+++ b/pyleecan/Classes/Circle.py
@@ -242,6 +242,8 @@ class Circle(Surface):
         Circle_dict["radius"] = self.radius
         if self.center is None:
             Circle_dict["center"] = None
+        elif isinstance(self.center, float):
+            Circle_dict["center"] = self.center
         else:
             Circle_dict["center"] = str(self.center)
         Circle_dict["line_label"] = self.line_label

--- a/pyleecan/Classes/Segment.py
+++ b/pyleecan/Classes/Segment.py
@@ -308,10 +308,14 @@ class Segment(Line):
         Segment_dict = super(Segment, self).as_dict()
         if self.begin is None:
             Segment_dict["begin"] = None
+        elif isinstance(self.begin, float):
+            Segment_dict["begin"] = self.begin
         else:
             Segment_dict["begin"] = str(self.begin)
         if self.end is None:
             Segment_dict["end"] = None
+        elif isinstance(self.end, float):
+            Segment_dict["end"] = self.end
         else:
             Segment_dict["end"] = str(self.end)
         # The class name is added to the dict for deserialisation purpose

--- a/pyleecan/Classes/Surface.py
+++ b/pyleecan/Classes/Surface.py
@@ -147,6 +147,8 @@ class Surface(FrozenClass):
         Surface_dict = dict()
         if self.point_ref is None:
             Surface_dict["point_ref"] = None
+        elif isinstance(self.point_ref, float):
+            Surface_dict["point_ref"] = self.point_ref
         else:
             Surface_dict["point_ref"] = str(self.point_ref)
         Surface_dict["label"] = self.label

--- a/pyleecan/GUI/Dialog/DMachineSetup/DMachineSetup.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/DMachineSetup.py
@@ -206,7 +206,7 @@ class DMachineSetup(Ui_DMachineSetup, QWidget):
                 return
             self.update_nav()
 
-    def update_nav(self):
+    def update_nav(self, next_step=None):
         """Update the nav list to match the step of the current machine"""
         mach_dict = mach_list[self.get_machine_index()]
         self.nav_step.blockSignals(True)
@@ -231,7 +231,10 @@ class DMachineSetup(Ui_DMachineSetup, QWidget):
             self.nav_step.addItem(str(index) + ": " + SPreview.step_name)
         self.update_enable_nav()
         self.nav_step.blockSignals(False)
-        self.nav_step.setCurrentRow(self.last_index)
+        if next_step is None:
+            self.nav_step.setCurrentRow(self.last_index)
+        else:
+            self.nav_step.setCurrentRow(next_step)
 
     def update_enable_nav(self):
         # Load for readibility

--- a/pyleecan/GUI/Dialog/DMachineSetup/SLamParam/SLamParam.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SLamParam/SLamParam.py
@@ -64,6 +64,8 @@ class SLamParam(Gen_SLamParam, QWidget):
             if self.obj.Kf1 is None:
                 # Default value for rotor is the stator one
                 self.obj.Kf1 = self.machine.stator.Kf1
+        if self.obj.axial_vent is None:
+            self.obj.axial_vent = list()
 
         self.w_mat.update(self.obj, "mat_type", self.matlib)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMachineType/SMachineType.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMachineType/SMachineType.py
@@ -125,8 +125,11 @@ class SMachineType(Gen_SMachineType, QWidget):
         if type(self.machine) is MachineSIPMSM:
             self.machine.rotor.slot.Zs = 2 * value
         elif type(self.machine) in [MachineIPMSM, MachineSyRM]:
-            for hole in self.machine.rotor.hole:
-                hole.Zh = 2 * value
+            if self.machine.rotor.hole is None:
+                self.machine.rotor.hole = list()
+            else:
+                for hole in self.machine.rotor.hole:
+                    hole.Zh = 2 * value
         elif self.machine.type_machine == 10:
             pass
         else:
@@ -170,7 +173,7 @@ class SMachineType(Gen_SMachineType, QWidget):
             self.set_p()
         # Update the GUI with the new machine
         self.parent().machine = self.machine
-        self.parent().update_nav()
+        self.parent().update_nav(next_step=0)
         if self.parent() is not None:
             self.parent().main_layout.removeWidget(self)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMagnet/SMagnet.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMagnet/SMagnet.py
@@ -77,6 +77,7 @@ class SMagnet(Ui_SMagnet, QDialog):
         # Set the GUI with the current values if provided
         if (
             type(self.machine.rotor.slot) is Slot
+            or self.machine.rotor.slot.magnet is None
             or type(self.machine.rotor.slot.magnet[0]) is Magnet
         ):
             # Magnet or slot not set
@@ -175,7 +176,8 @@ class SMagnet(Ui_SMagnet, QDialog):
         """
         # Save the mag
         slot = self.machine.rotor.slot
-        self.previous_mag[type(slot.magnet[0])] = slot
+        if slot.magnet is not None:
+            self.previous_mag[type(slot.magnet[0])] = slot
 
         if self.previous_mag[self.mag_type_index[index]] is None:
             # Set the slot

--- a/pyleecan/Generator/ClassGenerator/as_dict_method_generator.py
+++ b/pyleecan/Generator/ClassGenerator/as_dict_method_generator.py
@@ -43,6 +43,16 @@ def generate_as_dict(gen_dict, class_dict):
         elif prop["type"] == "complex":  # complex is not json serializable
             var_str += TAB2 + "if self." + prop["name"] + " is None:\n"
             var_str += TAB3 + class_name + '_dict["' + prop["name"] + '"] = None\n'
+            var_str += TAB2 + "elif isinstance(self." + prop["name"] + ", float):\n"
+            var_str += (
+                TAB3
+                + class_name
+                + '_dict["'
+                + prop["name"]
+                + '"] = self.'
+                + prop["name"]
+                + "\n"
+            )
             var_str += TAB2 + "else:\n"
             var_str += (
                 TAB3

--- a/pyleecan/Methods/Machine/Lamination/get_notch_list.py
+++ b/pyleecan/Methods/Machine/Lamination/get_notch_list.py
@@ -17,7 +17,7 @@ def get_notch_list(self, sym=1):
         list of dictionary with key: "begin_angle", "end_angle", "obj"
     """
 
-    if len(self.notch) == 0:  # No notch
+    if self.notch is None or len(self.notch) == 0:  # No notch
         return list()
     else:
         notch_list = self.notch[0].get_notch_list(sym=sym)


### PR DESCRIPTION
Hello all,

We recently enabled a list (and dict) of pyleecan type to be set as None. Which is now the default when calling set_None. In particular set_None is used to define all the default machine in the GUI which created some errors on some steps. This PR adds some checks for "None list" in the GUI. There may be other part of the code with this kind of problems. 

The class generator have also been updated to store float value for complex as float in the as_dict, it avoid converting float to "complex" (5+0j) when copying objects.

Best regards,
Pierre