### PR TITLE
[NF] compare method for all objects

### DIFF
--- a/Tests/Classes/test_compare.py
+++ b/Tests/Classes/test_compare.py
@@ -1,0 +1,92 @@
+from numpy import ones, pi, array, linspace, zeros
+from os.path import join
+import pytest
+
+from pyleecan.Classes.Simu1 import Simu1
+from pyleecan.Classes.InputCurrent import InputCurrent
+from pyleecan.Classes.ImportGenVectLin import ImportGenVectLin
+from pyleecan.Classes.ImportMatrixVal import ImportMatrixVal
+from pyleecan.Classes.WindingUD import WindingUD
+from pyleecan.Classes.MagFEMM import MagFEMM
+from pyleecan.Classes.PostPlot import PostPlot
+from pyleecan.Classes.PostFunction import PostFunction
+from pyleecan.Classes.Output import Output
+from pyleecan.Functions.load import load
+from pyleecan.definitions import DATA_DIR
+
+
+def test_compare():
+    """Test the compare method"""
+    # Create reference object
+    IPMSM_A = load(join(DATA_DIR, "Machine", "IPMSM_A.json"))
+    simu = Simu1(name="test_compare", machine=IPMSM_A)
+
+    # Initialization of the simulation starting point
+    simu.input = InputCurrent()
+    # Set time and space discretization
+    simu.input.time = ImportMatrixVal(
+        value=linspace(start=0, stop=0.015, num=4, endpoint=True)
+    )
+    simu.input.Na_tot = 1024
+
+    # Definition of the enforced output of the electrical module
+    simu.input.Is = ImportMatrixVal(
+        value=array(  # Stator currents as a function of time
+            [
+                [6.97244193e-06, 2.25353053e02, -2.25353060e02],
+                [-2.60215295e02, 1.30107654e02, 1.30107642e02],
+                [-6.97244208e-06, -2.25353053e02, 2.25353060e02],
+                [2.60215295e02, -1.30107654e02, -1.30107642e02],
+            ]
+        )
+    )
+    simu.input.Ir = None  # SPMSM machine => no rotor currents to define
+    simu.input.N0 = 3000  # Rotor speed [rpm]
+    simu.input.angle_rotor_initial = 0.5216 + pi  # Rotor position at t=0 [rad]
+
+    # Definition of the magnetic simulation (no symmetry)
+    simu.mag = MagFEMM(type_BH_stator=2, type_BH_rotor=2, is_periodicity_a=False)
+    simu.force = None
+    simu.struct = None
+    simu.postproc_list = [
+        PostPlot(param_list=[1, 2], param_dict={"test": 2}),
+        PostFunction(run="lambda out: out.elec.N0"),
+    ]
+
+    # Create the differences
+    simu2 = simu.copy()
+    simu2.machine.stator.L1 = 2  # float
+    simu2.machine.rotor.hole[0].magnet_0.mat_type.name = "Test "  # str
+    simu2.input.Nt_tot = 1234  # int
+    simu2.mag.is_periodicity_a = True  # bool
+    # complex
+    simu2.input.Is = zeros((4, 2))
+    # list(ndarray)
+    # dict(ndarray)
+    simu2.mag.transform_list = ["bla"]  # len(list)
+    simu2.postproc_list[0].param_list = [1, 3]  # list diff
+    simu2.postproc_list[0].param_dict["test2"] = 3  # len(dict)
+    simu2.postproc_list[1].run = "lambda out: out.elec.Id_ref"  # function
+    # dict diff
+    simu2.machine.stator.winding = WindingUD()  # pyleecan type diff
+    # pyleecan dict
+    # SciDataTool list
+    # SciDataTool dict
+
+    # Compare
+    diff_list = simu.compare(simu2, "simu")
+    assert "simu.machine.stator.L1" in diff_list
+    assert "simu.machine.rotor.hole[0].magnet_0.mat_type.name" in diff_list
+    assert "simu.input.Nt_tot" in diff_list
+    assert "simu.mag.is_periodicity_a" in diff_list
+    assert "simu.mag.transform_list" in diff_list
+    assert "simu.postproc_list[0].param_list" in diff_list
+    assert "simu.postproc_list[0].param_dict" in diff_list
+    assert "type(simu.machine.stator.winding)" in diff_list
+    assert "simu.input.Is.value" in diff_list
+    assert "simu.postproc_list[1].run" in diff_list
+    assert len(diff_list) == 10
+
+
+if __name__ == "__main__":
+    test_compare()

--- a/pyleecan/Classes/Arc.py
+++ b/pyleecan/Classes/Arc.py
@@ -162,6 +162,17 @@ class Arc(Line):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Line
+        diff_list.extend(super(Arc, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Arc1.py
+++ b/pyleecan/Classes/Arc1.py
@@ -291,6 +291,25 @@ class Arc1(Arc):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Arc
+        diff_list.extend(super(Arc1, self).compare(other, name=name))
+        if other._begin != self._begin:
+            diff_list.append(name + ".begin")
+        if other._end != self._end:
+            diff_list.append(name + ".end")
+        if other._radius != self._radius:
+            diff_list.append(name + ".radius")
+        if other._is_trigo_direction != self._is_trigo_direction:
+            diff_list.append(name + ".is_trigo_direction")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Arc2.py
+++ b/pyleecan/Classes/Arc2.py
@@ -284,6 +284,23 @@ class Arc2(Arc):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Arc
+        diff_list.extend(super(Arc2, self).compare(other, name=name))
+        if other._begin != self._begin:
+            diff_list.append(name + ".begin")
+        if other._center != self._center:
+            diff_list.append(name + ".center")
+        if other._angle != self._angle:
+            diff_list.append(name + ".angle")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Arc3.py
+++ b/pyleecan/Classes/Arc3.py
@@ -284,6 +284,23 @@ class Arc3(Arc):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Arc
+        diff_list.extend(super(Arc3, self).compare(other, name=name))
+        if other._begin != self._begin:
+            diff_list.append(name + ".begin")
+        if other._end != self._end:
+            diff_list.append(name + ".end")
+        if other._is_trigo_direction != self._is_trigo_direction:
+            diff_list.append(name + ".is_trigo_direction")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Bore.py
+++ b/pyleecan/Classes/Bore.py
@@ -64,6 +64,14 @@ class Bore(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/BoreFlower.py
+++ b/pyleecan/Classes/BoreFlower.py
@@ -107,6 +107,23 @@ class BoreFlower(Bore):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Bore
+        diff_list.extend(super(BoreFlower, self).compare(other, name=name))
+        if other._N != self._N:
+            diff_list.append(name + ".N")
+        if other._Rarc != self._Rarc:
+            diff_list.append(name + ".Rarc")
+        if other._alpha != self._alpha:
+            diff_list.append(name + ".alpha")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/BoreUD.py
+++ b/pyleecan/Classes/BoreUD.py
@@ -102,6 +102,30 @@ class BoreUD(Bore):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Bore
+        diff_list.extend(super(BoreUD, self).compare(other, name=name))
+        if (other.line_list is None and self.line_list is not None) or (
+            other.line_list is not None and self.line_list is None
+        ):
+            diff_list.append(name + ".line_list None mismatch")
+        elif len(other.line_list) != len(self.line_list):
+            diff_list.append("len(" + name + ".line_list)")
+        else:
+            for ii in range(len(other.line_list)):
+                diff_list.extend(
+                    self.line_list[ii].compare(
+                        other.line_list[ii], name=name + ".line_list[" + str(ii) + "]"
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/CellMat.py
+++ b/pyleecan/Classes/CellMat.py
@@ -194,6 +194,32 @@ class CellMat(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if not array_equal(other.connectivity, self.connectivity):
+            diff_list.append(name + ".connectivity")
+        if other._nb_cell != self._nb_cell:
+            diff_list.append(name + ".nb_cell")
+        if other._nb_pt_per_cell != self._nb_pt_per_cell:
+            diff_list.append(name + ".nb_pt_per_cell")
+        if not array_equal(other.indice, self.indice):
+            diff_list.append(name + ".indice")
+        if (other.interpolation is None and self.interpolation is not None) or (
+            other.interpolation is not None and self.interpolation is None
+        ):
+            diff_list.append(name + ".interpolation None mismatch")
+        elif self.interpolation is not None:
+            diff_list.extend(
+                self.interpolation.compare(
+                    other.interpolation, name=name + ".interpolation"
+                )
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Circle.py
+++ b/pyleecan/Classes/Circle.py
@@ -235,6 +235,23 @@ class Circle(Surface):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Surface
+        diff_list.extend(super(Circle, self).compare(other, name=name))
+        if other._radius != self._radius:
+            diff_list.append(name + ".radius")
+        if other._center != self._center:
+            diff_list.append(name + ".center")
+        if other._line_label != self._line_label:
+            diff_list.append(name + ".line_label")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/CondType11.py
+++ b/pyleecan/Classes/CondType11.py
@@ -239,6 +239,33 @@ class CondType11(Conductor):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Conductor
+        diff_list.extend(super(CondType11, self).compare(other, name=name))
+        if other._Hwire != self._Hwire:
+            diff_list.append(name + ".Hwire")
+        if other._Wwire != self._Wwire:
+            diff_list.append(name + ".Wwire")
+        if other._Nwppc_rad != self._Nwppc_rad:
+            diff_list.append(name + ".Nwppc_rad")
+        if other._Nwppc_tan != self._Nwppc_tan:
+            diff_list.append(name + ".Nwppc_tan")
+        if other._Wins_wire != self._Wins_wire:
+            diff_list.append(name + ".Wins_wire")
+        if other._Wins_coil != self._Wins_coil:
+            diff_list.append(name + ".Wins_coil")
+        if other._type_winding_shape != self._type_winding_shape:
+            diff_list.append(name + ".type_winding_shape")
+        if other._alpha_ew != self._alpha_ew:
+            diff_list.append(name + ".alpha_ew")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/CondType12.py
+++ b/pyleecan/Classes/CondType12.py
@@ -230,6 +230,27 @@ class CondType12(Conductor):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Conductor
+        diff_list.extend(super(CondType12, self).compare(other, name=name))
+        if other._Wwire != self._Wwire:
+            diff_list.append(name + ".Wwire")
+        if other._Wins_cond != self._Wins_cond:
+            diff_list.append(name + ".Wins_cond")
+        if other._Nwppc != self._Nwppc:
+            diff_list.append(name + ".Nwppc")
+        if other._Wins_wire != self._Wins_wire:
+            diff_list.append(name + ".Wins_wire")
+        if other._Kwoh != self._Kwoh:
+            diff_list.append(name + ".Kwoh")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/CondType21.py
+++ b/pyleecan/Classes/CondType21.py
@@ -185,6 +185,23 @@ class CondType21(Conductor):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Conductor
+        diff_list.extend(super(CondType21, self).compare(other, name=name))
+        if other._Hbar != self._Hbar:
+            diff_list.append(name + ".Hbar")
+        if other._Wbar != self._Wbar:
+            diff_list.append(name + ".Wbar")
+        if other._Wins != self._Wins:
+            diff_list.append(name + ".Wins")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/CondType22.py
+++ b/pyleecan/Classes/CondType22.py
@@ -120,6 +120,19 @@ class CondType22(Conductor):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Conductor
+        diff_list.extend(super(CondType22, self).compare(other, name=name))
+        if other._Sbar != self._Sbar:
+            diff_list.append(name + ".Sbar")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Conductor.py
+++ b/pyleecan/Classes/Conductor.py
@@ -106,6 +106,30 @@ class Conductor(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.cond_mat is None and self.cond_mat is not None) or (
+            other.cond_mat is not None and self.cond_mat is None
+        ):
+            diff_list.append(name + ".cond_mat None mismatch")
+        elif self.cond_mat is not None:
+            diff_list.extend(
+                self.cond_mat.compare(other.cond_mat, name=name + ".cond_mat")
+            )
+        if (other.ins_mat is None and self.ins_mat is not None) or (
+            other.ins_mat is not None and self.ins_mat is None
+        ):
+            diff_list.append(name + ".ins_mat None mismatch")
+        elif self.ins_mat is not None:
+            diff_list.extend(
+                self.ins_mat.compare(other.ins_mat, name=name + ".ins_mat")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/DXFImport.py
+++ b/pyleecan/Classes/DXFImport.py
@@ -112,6 +112,20 @@ class DXFImport(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._file_path != self._file_path:
+            diff_list.append(name + ".file_path")
+        if other._surf_dict != self._surf_dict:
+            diff_list.append(name + ".surf_dict")
+        if other._BC_list != self._BC_list:
+            diff_list.append(name + ".BC_list")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/DataKeeper.py
+++ b/pyleecan/Classes/DataKeeper.py
@@ -134,6 +134,26 @@ class DataKeeper(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._symbol != self._symbol:
+            diff_list.append(name + ".symbol")
+        if other._unit != self._unit:
+            diff_list.append(name + ".unit")
+        if other._keeper_str != self._keeper_str:
+            diff_list.append(name + ".keeper")
+        if other._error_keeper_str != self._error_keeper_str:
+            diff_list.append(name + ".error_keeper")
+        if other._result != self._result:
+            diff_list.append(name + ".result")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Drive.py
+++ b/pyleecan/Classes/Drive.py
@@ -88,6 +88,20 @@ class Drive(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._Umax != self._Umax:
+            diff_list.append(name + ".Umax")
+        if other._Imax != self._Imax:
+            diff_list.append(name + ".Imax")
+        if other._is_current != self._is_current:
+            diff_list.append(name + ".is_current")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/DriveWave.py
+++ b/pyleecan/Classes/DriveWave.py
@@ -112,6 +112,23 @@ class DriveWave(Drive):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Drive
+        diff_list.extend(super(DriveWave, self).compare(other, name=name))
+        if (other.wave is None and self.wave is not None) or (
+            other.wave is not None and self.wave is None
+        ):
+            diff_list.append(name + ".wave None mismatch")
+        elif self.wave is not None:
+            diff_list.extend(self.wave.compare(other.wave, name=name + ".wave"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/EEC.py
+++ b/pyleecan/Classes/EEC.py
@@ -64,6 +64,14 @@ class EEC(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/EEC_PMSM.py
+++ b/pyleecan/Classes/EEC_PMSM.py
@@ -189,6 +189,41 @@ class EEC_PMSM(EEC):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from EEC
+        diff_list.extend(super(EEC_PMSM, self).compare(other, name=name))
+        if (other.indmag is None and self.indmag is not None) or (
+            other.indmag is not None and self.indmag is None
+        ):
+            diff_list.append(name + ".indmag None mismatch")
+        elif self.indmag is not None:
+            diff_list.extend(self.indmag.compare(other.indmag, name=name + ".indmag"))
+        if (other.fluxlink is None and self.fluxlink is not None) or (
+            other.fluxlink is not None and self.fluxlink is None
+        ):
+            diff_list.append(name + ".fluxlink None mismatch")
+        elif self.fluxlink is not None:
+            diff_list.extend(
+                self.fluxlink.compare(other.fluxlink, name=name + ".fluxlink")
+            )
+        if other._parameters != self._parameters:
+            diff_list.append(name + ".parameters")
+        if other._freq0 != self._freq0:
+            diff_list.append(name + ".freq0")
+        if (other.drive is None and self.drive is not None) or (
+            other.drive is not None and self.drive is None
+        ):
+            diff_list.append(name + ".drive None mismatch")
+        elif self.drive is not None:
+            diff_list.extend(self.drive.compare(other.drive, name=name + ".drive"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/EEC_SCIM.py
+++ b/pyleecan/Classes/EEC_SCIM.py
@@ -195,6 +195,33 @@ class EEC_SCIM(EEC):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from EEC
+        diff_list.extend(super(EEC_SCIM, self).compare(other, name=name))
+        if other._I != self._I:
+            diff_list.append(name + ".I")
+        if other._parameters != self._parameters:
+            diff_list.append(name + ".parameters")
+        if other._is_periodicity_a != self._is_periodicity_a:
+            diff_list.append(name + ".is_periodicity_a")
+        if other._nb_worker != self._nb_worker:
+            diff_list.append(name + ".nb_worker")
+        if other._N0 != self._N0:
+            diff_list.append(name + ".N0")
+        if other._felec != self._felec:
+            diff_list.append(name + ".felec")
+        if other._Nt_tot != self._Nt_tot:
+            diff_list.append(name + ".Nt_tot")
+        if other._Nrev != self._Nrev:
+            diff_list.append(name + ".Nrev")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Electrical.py
+++ b/pyleecan/Classes/Electrical.py
@@ -137,6 +137,22 @@ class Electrical(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.eec is None and self.eec is not None) or (
+            other.eec is not None and self.eec is None
+        ):
+            diff_list.append(name + ".eec None mismatch")
+        elif self.eec is not None:
+            diff_list.extend(self.eec.compare(other.eec, name=name + ".eec"))
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Elmer.py
+++ b/pyleecan/Classes/Elmer.py
@@ -74,6 +74,16 @@ class Elmer(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ElmerResults.py
+++ b/pyleecan/Classes/ElmerResults.py
@@ -172,6 +172,27 @@ class ElmerResults(Elmer):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Elmer
+        diff_list.extend(super(ElmerResults, self).compare(other, name=name))
+        if other._data != self._data:
+            diff_list.append(name + ".data")
+        if other._file != self._file:
+            diff_list.append(name + ".file")
+        if other._usecols != self._usecols:
+            diff_list.append(name + ".usecols")
+        if other._columns != self._columns:
+            diff_list.append(name + ".columns")
+        if other._is_scalars != self._is_scalars:
+            diff_list.append(name + ".is_scalars")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ElmerResultsVTU.py
+++ b/pyleecan/Classes/ElmerResultsVTU.py
@@ -118,6 +118,23 @@ class ElmerResultsVTU(Elmer):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Elmer
+        diff_list.extend(super(ElmerResultsVTU, self).compare(other, name=name))
+        if other._label != self._label:
+            diff_list.append(name + ".label")
+        if other._file_path != self._file_path:
+            diff_list.append(name + ".file_path")
+        if other._store_dict != self._store_dict:
+            diff_list.append(name + ".store_dict")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/FPGNSeg.py
+++ b/pyleecan/Classes/FPGNSeg.py
@@ -96,6 +96,19 @@ class FPGNSeg(GaussPoint):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from GaussPoint
+        diff_list.extend(super(FPGNSeg, self).compare(other, name=name))
+        if other._nb_gauss_point != self._nb_gauss_point:
+            diff_list.append(name + ".nb_gauss_point")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/FPGNTri.py
+++ b/pyleecan/Classes/FPGNTri.py
@@ -96,6 +96,19 @@ class FPGNTri(GaussPoint):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from GaussPoint
+        diff_list.extend(super(FPGNTri, self).compare(other, name=name))
+        if other._nb_gauss_point != self._nb_gauss_point:
+            diff_list.append(name + ".nb_gauss_point")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/FluxLink.py
+++ b/pyleecan/Classes/FluxLink.py
@@ -64,6 +64,14 @@ class FluxLink(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/FluxLinkFEMM.py
+++ b/pyleecan/Classes/FluxLinkFEMM.py
@@ -155,6 +155,29 @@ class FluxLinkFEMM(FluxLink):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from FluxLink
+        diff_list.extend(super(FluxLinkFEMM, self).compare(other, name=name))
+        if other._FEMM_dict != self._FEMM_dict:
+            diff_list.append(name + ".FEMM_dict")
+        if other._type_calc_leakage != self._type_calc_leakage:
+            diff_list.append(name + ".type_calc_leakage")
+        if other._is_sliding_band != self._is_sliding_band:
+            diff_list.append(name + ".is_sliding_band")
+        if other._is_periodicity_a != self._is_periodicity_a:
+            diff_list.append(name + ".is_periodicity_a")
+        if other._Nt_tot != self._Nt_tot:
+            diff_list.append(name + ".Nt_tot")
+        if other._Kgeo_fineness != self._Kgeo_fineness:
+            diff_list.append(name + ".Kgeo_fineness")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Force.py
+++ b/pyleecan/Classes/Force.py
@@ -167,6 +167,26 @@ class Force(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._is_periodicity_t != self._is_periodicity_t:
+            diff_list.append(name + ".is_periodicity_t")
+        if other._is_periodicity_a != self._is_periodicity_a:
+            diff_list.append(name + ".is_periodicity_a")
+        if other._is_agsf_transfer != self._is_agsf_transfer:
+            diff_list.append(name + ".is_agsf_transfer")
+        if other._max_wavenumber_transfer != self._max_wavenumber_transfer:
+            diff_list.append(name + ".max_wavenumber_transfer")
+        if other._Rsbo_enforced_transfer != self._Rsbo_enforced_transfer:
+            diff_list.append(name + ".Rsbo_enforced_transfer")
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ForceMT.py
+++ b/pyleecan/Classes/ForceMT.py
@@ -134,6 +134,17 @@ class ForceMT(Force):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Force
+        diff_list.extend(super(ForceMT, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Frame.py
+++ b/pyleecan/Classes/Frame.py
@@ -205,6 +205,28 @@ class Frame(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._Lfra != self._Lfra:
+            diff_list.append(name + ".Lfra")
+        if other._Rint != self._Rint:
+            diff_list.append(name + ".Rint")
+        if other._Rext != self._Rext:
+            diff_list.append(name + ".Rext")
+        if (other.mat_type is None and self.mat_type is not None) or (
+            other.mat_type is not None and self.mat_type is None
+        ):
+            diff_list.append(name + ".mat_type None mismatch")
+        elif self.mat_type is not None:
+            diff_list.extend(
+                self.mat_type.compare(other.mat_type, name=name + ".mat_type")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/GUIOption.py
+++ b/pyleecan/Classes/GUIOption.py
@@ -78,6 +78,20 @@ class GUIOption(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.unit is None and self.unit is not None) or (
+            other.unit is not None and self.unit is None
+        ):
+            diff_list.append(name + ".unit None mismatch")
+        elif self.unit is not None:
+            diff_list.extend(self.unit.compare(other.unit, name=name + ".unit"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/GaussPoint.py
+++ b/pyleecan/Classes/GaussPoint.py
@@ -64,6 +64,14 @@ class GaussPoint(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Hole.py
+++ b/pyleecan/Classes/Hole.py
@@ -267,6 +267,24 @@ class Hole(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._Zh != self._Zh:
+            diff_list.append(name + ".Zh")
+        if (other.mat_void is None and self.mat_void is not None) or (
+            other.mat_void is not None and self.mat_void is None
+        ):
+            diff_list.append(name + ".mat_void None mismatch")
+        elif self.mat_void is not None:
+            diff_list.extend(
+                self.mat_void.compare(other.mat_void, name=name + ".mat_void")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleM50.py
+++ b/pyleecan/Classes/HoleM50.py
@@ -331,6 +331,53 @@ class HoleM50(HoleMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from HoleMag
+        diff_list.extend(super(HoleM50, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._H3 != self._H3:
+            diff_list.append(name + ".H3")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H4 != self._H4:
+            diff_list.append(name + ".H4")
+        if other._W4 != self._W4:
+            diff_list.append(name + ".W4")
+        if (other.magnet_0 is None and self.magnet_0 is not None) or (
+            other.magnet_0 is not None and self.magnet_0 is None
+        ):
+            diff_list.append(name + ".magnet_0 None mismatch")
+        elif self.magnet_0 is not None:
+            diff_list.extend(
+                self.magnet_0.compare(other.magnet_0, name=name + ".magnet_0")
+            )
+        if (other.magnet_1 is None and self.magnet_1 is not None) or (
+            other.magnet_1 is not None and self.magnet_1 is None
+        ):
+            diff_list.append(name + ".magnet_1 None mismatch")
+        elif self.magnet_1 is not None:
+            diff_list.extend(
+                self.magnet_1.compare(other.magnet_1, name=name + ".magnet_1")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleM51.py
+++ b/pyleecan/Classes/HoleM51.py
@@ -349,6 +349,63 @@ class HoleM51(HoleMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from HoleMag
+        diff_list.extend(super(HoleM51, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._W4 != self._W4:
+            diff_list.append(name + ".W4")
+        if other._W5 != self._W5:
+            diff_list.append(name + ".W5")
+        if other._W6 != self._W6:
+            diff_list.append(name + ".W6")
+        if other._W7 != self._W7:
+            diff_list.append(name + ".W7")
+        if (other.magnet_0 is None and self.magnet_0 is not None) or (
+            other.magnet_0 is not None and self.magnet_0 is None
+        ):
+            diff_list.append(name + ".magnet_0 None mismatch")
+        elif self.magnet_0 is not None:
+            diff_list.extend(
+                self.magnet_0.compare(other.magnet_0, name=name + ".magnet_0")
+            )
+        if (other.magnet_1 is None and self.magnet_1 is not None) or (
+            other.magnet_1 is not None and self.magnet_1 is None
+        ):
+            diff_list.append(name + ".magnet_1 None mismatch")
+        elif self.magnet_1 is not None:
+            diff_list.extend(
+                self.magnet_1.compare(other.magnet_1, name=name + ".magnet_1")
+            )
+        if (other.magnet_2 is None and self.magnet_2 is not None) or (
+            other.magnet_2 is not None and self.magnet_2 is None
+        ):
+            diff_list.append(name + ".magnet_2 None mismatch")
+        elif self.magnet_2 is not None:
+            diff_list.extend(
+                self.magnet_2.compare(other.magnet_2, name=name + ".magnet_2")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleM52.py
+++ b/pyleecan/Classes/HoleM52.py
@@ -301,6 +301,35 @@ class HoleM52(HoleMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from HoleMag
+        diff_list.extend(super(HoleM52, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if (other.magnet_0 is None and self.magnet_0 is not None) or (
+            other.magnet_0 is not None and self.magnet_0 is None
+        ):
+            diff_list.append(name + ".magnet_0 None mismatch")
+        elif self.magnet_0 is not None:
+            diff_list.extend(
+                self.magnet_0.compare(other.magnet_0, name=name + ".magnet_0")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleM53.py
+++ b/pyleecan/Classes/HoleM53.py
@@ -317,6 +317,49 @@ class HoleM53(HoleMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from HoleMag
+        diff_list.extend(super(HoleM53, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._H3 != self._H3:
+            diff_list.append(name + ".H3")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._W4 != self._W4:
+            diff_list.append(name + ".W4")
+        if (other.magnet_0 is None and self.magnet_0 is not None) or (
+            other.magnet_0 is not None and self.magnet_0 is None
+        ):
+            diff_list.append(name + ".magnet_0 None mismatch")
+        elif self.magnet_0 is not None:
+            diff_list.extend(
+                self.magnet_0.compare(other.magnet_0, name=name + ".magnet_0")
+            )
+        if (other.magnet_1 is None and self.magnet_1 is not None) or (
+            other.magnet_1 is not None and self.magnet_1 is None
+        ):
+            diff_list.append(name + ".magnet_1 None mismatch")
+        elif self.magnet_1 is not None:
+            diff_list.extend(
+                self.magnet_1.compare(other.magnet_1, name=name + ".magnet_1")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleM54.py
+++ b/pyleecan/Classes/HoleM54.py
@@ -207,6 +207,25 @@ class HoleM54(Hole):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Hole
+        diff_list.extend(super(HoleM54, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleM57.py
+++ b/pyleecan/Classes/HoleM57.py
@@ -282,6 +282,47 @@ class HoleM57(HoleMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from HoleMag
+        diff_list.extend(super(HoleM57, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._W4 != self._W4:
+            diff_list.append(name + ".W4")
+        if (other.magnet_0 is None and self.magnet_0 is not None) or (
+            other.magnet_0 is not None and self.magnet_0 is None
+        ):
+            diff_list.append(name + ".magnet_0 None mismatch")
+        elif self.magnet_0 is not None:
+            diff_list.extend(
+                self.magnet_0.compare(other.magnet_0, name=name + ".magnet_0")
+            )
+        if (other.magnet_1 is None and self.magnet_1 is not None) or (
+            other.magnet_1 is not None and self.magnet_1 is None
+        ):
+            diff_list.append(name + ".magnet_1 None mismatch")
+        elif self.magnet_1 is not None:
+            diff_list.extend(
+                self.magnet_1.compare(other.magnet_1, name=name + ".magnet_1")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleM58.py
+++ b/pyleecan/Classes/HoleM58.py
@@ -278,6 +278,41 @@ class HoleM58(HoleMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from HoleMag
+        diff_list.extend(super(HoleM58, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._R0 != self._R0:
+            diff_list.append(name + ".R0")
+        if (other.magnet_0 is None and self.magnet_0 is not None) or (
+            other.magnet_0 is not None and self.magnet_0 is None
+        ):
+            diff_list.append(name + ".magnet_0 None mismatch")
+        elif self.magnet_0 is not None:
+            diff_list.extend(
+                self.magnet_0.compare(other.magnet_0, name=name + ".magnet_0")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleMag.py
+++ b/pyleecan/Classes/HoleMag.py
@@ -177,6 +177,17 @@ class HoleMag(Hole):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Hole
+        diff_list.extend(super(HoleMag, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/HoleUD.py
+++ b/pyleecan/Classes/HoleUD.py
@@ -192,6 +192,43 @@ class HoleUD(HoleMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from HoleMag
+        diff_list.extend(super(HoleUD, self).compare(other, name=name))
+        if (other.surf_list is None and self.surf_list is not None) or (
+            other.surf_list is not None and self.surf_list is None
+        ):
+            diff_list.append(name + ".surf_list None mismatch")
+        elif len(other.surf_list) != len(self.surf_list):
+            diff_list.append("len(" + name + ".surf_list)")
+        else:
+            for ii in range(len(other.surf_list)):
+                diff_list.extend(
+                    self.surf_list[ii].compare(
+                        other.surf_list[ii], name=name + ".surf_list[" + str(ii) + "]"
+                    )
+                )
+        if (other.magnet_dict is None and self.magnet_dict is not None) or (
+            other.magnet_dict is not None and self.magnet_dict is None
+        ):
+            diff_list.append(name + ".magnet_dict None mismatch")
+        elif len(other.magnet_dict) != len(self.magnet_dict):
+            diff_list.append("len(" + name + "magnet_dict)")
+        else:
+            for key in self.magnet_dict:
+                diff_list.extend(
+                    self.magnet_dict[key].compare(
+                        other.magnet_dict[key], name=name + ".magnet_dict"
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Import.py
+++ b/pyleecan/Classes/Import.py
@@ -64,6 +64,14 @@ class Import(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportData.py
+++ b/pyleecan/Classes/ImportData.py
@@ -147,6 +147,43 @@ class ImportData(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.axes is None and self.axes is not None) or (
+            other.axes is not None and self.axes is None
+        ):
+            diff_list.append(name + ".axes None mismatch")
+        elif len(other.axes) != len(self.axes):
+            diff_list.append("len(" + name + ".axes)")
+        else:
+            for ii in range(len(other.axes)):
+                diff_list.extend(
+                    self.axes[ii].compare(
+                        other.axes[ii], name=name + ".axes[" + str(ii) + "]"
+                    )
+                )
+        if (other.field is None and self.field is not None) or (
+            other.field is not None and self.field is None
+        ):
+            diff_list.append(name + ".field None mismatch")
+        elif self.field is not None:
+            diff_list.extend(self.field.compare(other.field, name=name + ".field"))
+        if other._unit != self._unit:
+            diff_list.append(name + ".unit")
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._symbol != self._symbol:
+            diff_list.append(name + ".symbol")
+        if other._normalizations != self._normalizations:
+            diff_list.append(name + ".normalizations")
+        if other._symmetries != self._symmetries:
+            diff_list.append(name + ".symmetries")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportGenMatrixSin.py
+++ b/pyleecan/Classes/ImportGenMatrixSin.py
@@ -122,6 +122,30 @@ class ImportGenMatrixSin(ImportMatrix):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ImportMatrix
+        diff_list.extend(super(ImportGenMatrixSin, self).compare(other, name=name))
+        if (other.sin_list is None and self.sin_list is not None) or (
+            other.sin_list is not None and self.sin_list is None
+        ):
+            diff_list.append(name + ".sin_list None mismatch")
+        elif len(other.sin_list) != len(self.sin_list):
+            diff_list.append("len(" + name + ".sin_list)")
+        else:
+            for ii in range(len(other.sin_list)):
+                diff_list.extend(
+                    self.sin_list[ii].compare(
+                        other.sin_list[ii], name=name + ".sin_list[" + str(ii) + "]"
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportGenToothSaw.py
+++ b/pyleecan/Classes/ImportGenToothSaw.py
@@ -138,6 +138,29 @@ class ImportGenToothSaw(ImportMatrix):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ImportMatrix
+        diff_list.extend(super(ImportGenToothSaw, self).compare(other, name=name))
+        if other._type_signal != self._type_signal:
+            diff_list.append(name + ".type_signal")
+        if other._f != self._f:
+            diff_list.append(name + ".f")
+        if other._A != self._A:
+            diff_list.append(name + ".A")
+        if other._N != self._N:
+            diff_list.append(name + ".N")
+        if other._Tf != self._Tf:
+            diff_list.append(name + ".Tf")
+        if other._Dt != self._Dt:
+            diff_list.append(name + ".Dt")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportGenVectLin.py
+++ b/pyleecan/Classes/ImportGenVectLin.py
@@ -155,6 +155,25 @@ class ImportGenVectLin(ImportMatrix):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ImportMatrix
+        diff_list.extend(super(ImportGenVectLin, self).compare(other, name=name))
+        if other._start != self._start:
+            diff_list.append(name + ".start")
+        if other._stop != self._stop:
+            diff_list.append(name + ".stop")
+        if other._num != self._num:
+            diff_list.append(name + ".num")
+        if other._endpoint != self._endpoint:
+            diff_list.append(name + ".endpoint")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportGenVectSin.py
+++ b/pyleecan/Classes/ImportGenVectSin.py
@@ -131,6 +131,27 @@ class ImportGenVectSin(ImportMatrix):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ImportMatrix
+        diff_list.extend(super(ImportGenVectSin, self).compare(other, name=name))
+        if other._f != self._f:
+            diff_list.append(name + ".f")
+        if other._A != self._A:
+            diff_list.append(name + ".A")
+        if other._Phi != self._Phi:
+            diff_list.append(name + ".Phi")
+        if other._N != self._N:
+            diff_list.append(name + ".N")
+        if other._Tf != self._Tf:
+            diff_list.append(name + ".Tf")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportMatlab.py
+++ b/pyleecan/Classes/ImportMatlab.py
@@ -108,6 +108,21 @@ class ImportMatlab(ImportMatrix):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ImportMatrix
+        diff_list.extend(super(ImportMatlab, self).compare(other, name=name))
+        if other._file_path != self._file_path:
+            diff_list.append(name + ".file_path")
+        if other._var_name != self._var_name:
+            diff_list.append(name + ".var_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportMatrix.py
+++ b/pyleecan/Classes/ImportMatrix.py
@@ -95,6 +95,19 @@ class ImportMatrix(Import):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Import
+        diff_list.extend(super(ImportMatrix, self).compare(other, name=name))
+        if other._is_transpose != self._is_transpose:
+            diff_list.append(name + ".is_transpose")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportMatrixVal.py
+++ b/pyleecan/Classes/ImportMatrixVal.py
@@ -104,6 +104,19 @@ class ImportMatrixVal(ImportMatrix):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ImportMatrix
+        diff_list.extend(super(ImportMatrixVal, self).compare(other, name=name))
+        if not array_equal(other.value, self.value):
+            diff_list.append(name + ".value")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportMatrixXls.py
+++ b/pyleecan/Classes/ImportMatrixXls.py
@@ -138,6 +138,29 @@ class ImportMatrixXls(ImportMatrix):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ImportMatrix
+        diff_list.extend(super(ImportMatrixXls, self).compare(other, name=name))
+        if other._file_path != self._file_path:
+            diff_list.append(name + ".file_path")
+        if other._sheet != self._sheet:
+            diff_list.append(name + ".sheet")
+        if other._skiprows != self._skiprows:
+            diff_list.append(name + ".skiprows")
+        if other._usecols != self._usecols:
+            diff_list.append(name + ".usecols")
+        if other._axes_colrows != self._axes_colrows:
+            diff_list.append(name + ".axes_colrows")
+        if other._is_allsheets != self._is_allsheets:
+            diff_list.append(name + ".is_allsheets")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ImportVectorField.py
+++ b/pyleecan/Classes/ImportVectorField.py
@@ -119,6 +119,31 @@ class ImportVectorField(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.components is None and self.components is not None) or (
+            other.components is not None and self.components is None
+        ):
+            diff_list.append(name + ".components None mismatch")
+        elif len(other.components) != len(self.components):
+            diff_list.append("len(" + name + "components)")
+        else:
+            for key in self.components:
+                diff_list.extend(
+                    self.components[key].compare(
+                        other.components[key], name=name + ".components"
+                    )
+                )
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._symbol != self._symbol:
+            diff_list.append(name + ".symbol")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/IndMag.py
+++ b/pyleecan/Classes/IndMag.py
@@ -64,6 +64,14 @@ class IndMag(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/IndMagFEMM.py
+++ b/pyleecan/Classes/IndMagFEMM.py
@@ -153,6 +153,29 @@ class IndMagFEMM(IndMag):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from IndMag
+        diff_list.extend(super(IndMagFEMM, self).compare(other, name=name))
+        if other._FEMM_dict != self._FEMM_dict:
+            diff_list.append(name + ".FEMM_dict")
+        if other._type_calc_leakage != self._type_calc_leakage:
+            diff_list.append(name + ".type_calc_leakage")
+        if other._is_sliding_band != self._is_sliding_band:
+            diff_list.append(name + ".is_sliding_band")
+        if other._is_periodicity_a != self._is_periodicity_a:
+            diff_list.append(name + ".is_periodicity_a")
+        if other._Nt_tot != self._Nt_tot:
+            diff_list.append(name + ".Nt_tot")
+        if other._Kgeo_fineness != self._Kgeo_fineness:
+            diff_list.append(name + ".Kgeo_fineness")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Input.py
+++ b/pyleecan/Classes/Input.py
@@ -172,6 +172,34 @@ class Input(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.time is None and self.time is not None) or (
+            other.time is not None and self.time is None
+        ):
+            diff_list.append(name + ".time None mismatch")
+        elif self.time is not None:
+            diff_list.extend(self.time.compare(other.time, name=name + ".time"))
+        if (other.angle is None and self.angle is not None) or (
+            other.angle is not None and self.angle is None
+        ):
+            diff_list.append(name + ".angle None mismatch")
+        elif self.angle is not None:
+            diff_list.extend(self.angle.compare(other.angle, name=name + ".angle"))
+        if other._Nt_tot != self._Nt_tot:
+            diff_list.append(name + ".Nt_tot")
+        if other._Nrev != self._Nrev:
+            diff_list.append(name + ".Nrev")
+        if other._Na_tot != self._Na_tot:
+            diff_list.append(name + ".Na_tot")
+        if other._N0 != self._N0:
+            diff_list.append(name + ".N0")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/InputCurrent.py
+++ b/pyleecan/Classes/InputCurrent.py
@@ -214,6 +214,49 @@ class InputCurrent(Input):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Input
+        diff_list.extend(super(InputCurrent, self).compare(other, name=name))
+        if (other.Is is None and self.Is is not None) or (
+            other.Is is not None and self.Is is None
+        ):
+            diff_list.append(name + ".Is None mismatch")
+        elif self.Is is not None:
+            diff_list.extend(self.Is.compare(other.Is, name=name + ".Is"))
+        if (other.Ir is None and self.Ir is not None) or (
+            other.Ir is not None and self.Ir is None
+        ):
+            diff_list.append(name + ".Ir None mismatch")
+        elif self.Ir is not None:
+            diff_list.extend(self.Ir.compare(other.Ir, name=name + ".Ir"))
+        if (other.angle_rotor is None and self.angle_rotor is not None) or (
+            other.angle_rotor is not None and self.angle_rotor is None
+        ):
+            diff_list.append(name + ".angle_rotor None mismatch")
+        elif self.angle_rotor is not None:
+            diff_list.extend(
+                self.angle_rotor.compare(other.angle_rotor, name=name + ".angle_rotor")
+            )
+        if other._rot_dir != self._rot_dir:
+            diff_list.append(name + ".rot_dir")
+        if other._angle_rotor_initial != self._angle_rotor_initial:
+            diff_list.append(name + ".angle_rotor_initial")
+        if other._Tem_av_ref != self._Tem_av_ref:
+            diff_list.append(name + ".Tem_av_ref")
+        if other._Id_ref != self._Id_ref:
+            diff_list.append(name + ".Id_ref")
+        if other._Iq_ref != self._Iq_ref:
+            diff_list.append(name + ".Iq_ref")
+        if other._felec != self._felec:
+            diff_list.append(name + ".felec")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/InputElec.py
+++ b/pyleecan/Classes/InputElec.py
@@ -186,6 +186,29 @@ class InputElec(Input):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Input
+        diff_list.extend(super(InputElec, self).compare(other, name=name))
+        if other._rot_dir != self._rot_dir:
+            diff_list.append(name + ".rot_dir")
+        if other._Id_ref != self._Id_ref:
+            diff_list.append(name + ".Id_ref")
+        if other._Iq_ref != self._Iq_ref:
+            diff_list.append(name + ".Iq_ref")
+        if other._Ud_ref != self._Ud_ref:
+            diff_list.append(name + ".Ud_ref")
+        if other._Uq_ref != self._Uq_ref:
+            diff_list.append(name + ".Uq_ref")
+        if other._felec != self._felec:
+            diff_list.append(name + ".felec")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/InputFlux.py
+++ b/pyleecan/Classes/InputFlux.py
@@ -198,6 +198,35 @@ class InputFlux(Input):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Input
+        diff_list.extend(super(InputFlux, self).compare(other, name=name))
+        if other._per_a != self._per_a:
+            diff_list.append(name + ".per_a")
+        if other._per_t != self._per_t:
+            diff_list.append(name + ".per_t")
+        if other._is_antiper_a != self._is_antiper_a:
+            diff_list.append(name + ".is_antiper_a")
+        if other._is_antiper_t != self._is_antiper_t:
+            diff_list.append(name + ".is_antiper_t")
+        if other._B_dict != self._B_dict:
+            diff_list.append(name + ".B_dict")
+        if other._unit != self._unit:
+            diff_list.append(name + ".unit")
+        if (other.OP is None and self.OP is not None) or (
+            other.OP is not None and self.OP is None
+        ):
+            diff_list.append(name + ".OP None mismatch")
+        elif self.OP is not None:
+            diff_list.extend(self.OP.compare(other.OP, name=name + ".OP"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/InputForce.py
+++ b/pyleecan/Classes/InputForce.py
@@ -127,6 +127,23 @@ class InputForce(Input):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Input
+        diff_list.extend(super(InputForce, self).compare(other, name=name))
+        if (other.P is None and self.P is not None) or (
+            other.P is not None and self.P is None
+        ):
+            diff_list.append(name + ".P None mismatch")
+        elif self.P is not None:
+            diff_list.extend(self.P.compare(other.P, name=name + ".P"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Interpolation.py
+++ b/pyleecan/Classes/Interpolation.py
@@ -116,6 +116,40 @@ class Interpolation(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.ref_cell is None and self.ref_cell is not None) or (
+            other.ref_cell is not None and self.ref_cell is None
+        ):
+            diff_list.append(name + ".ref_cell None mismatch")
+        elif self.ref_cell is not None:
+            diff_list.extend(
+                self.ref_cell.compare(other.ref_cell, name=name + ".ref_cell")
+            )
+        if (other.gauss_point is None and self.gauss_point is not None) or (
+            other.gauss_point is not None and self.gauss_point is None
+        ):
+            diff_list.append(name + ".gauss_point None mismatch")
+        elif self.gauss_point is not None:
+            diff_list.extend(
+                self.gauss_point.compare(other.gauss_point, name=name + ".gauss_point")
+            )
+        if (other.scalar_product is None and self.scalar_product is not None) or (
+            other.scalar_product is not None and self.scalar_product is None
+        ):
+            diff_list.append(name + ".scalar_product None mismatch")
+        elif self.scalar_product is not None:
+            diff_list.extend(
+                self.scalar_product.compare(
+                    other.scalar_product, name=name + ".scalar_product"
+                )
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LamHole.py
+++ b/pyleecan/Classes/LamHole.py
@@ -324,6 +324,36 @@ class LamHole(Lamination):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Lamination
+        diff_list.extend(super(LamHole, self).compare(other, name=name))
+        if (other.hole is None and self.hole is not None) or (
+            other.hole is not None and self.hole is None
+        ):
+            diff_list.append(name + ".hole None mismatch")
+        elif len(other.hole) != len(self.hole):
+            diff_list.append("len(" + name + ".hole)")
+        else:
+            for ii in range(len(other.hole)):
+                diff_list.extend(
+                    self.hole[ii].compare(
+                        other.hole[ii], name=name + ".hole[" + str(ii) + "]"
+                    )
+                )
+        if (other.bore is None and self.bore is not None) or (
+            other.bore is not None and self.bore is None
+        ):
+            diff_list.append(name + ".bore None mismatch")
+        elif self.bore is not None:
+            diff_list.extend(self.bore.compare(other.bore, name=name + ".bore"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LamSlot.py
+++ b/pyleecan/Classes/LamSlot.py
@@ -312,6 +312,23 @@ class LamSlot(Lamination):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Lamination
+        diff_list.extend(super(LamSlot, self).compare(other, name=name))
+        if (other.slot is None and self.slot is not None) or (
+            other.slot is not None and self.slot is None
+        ):
+            diff_list.append(name + ".slot None mismatch")
+        elif self.slot is not None:
+            diff_list.extend(self.slot.compare(other.slot, name=name + ".slot"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LamSlotMag.py
+++ b/pyleecan/Classes/LamSlotMag.py
@@ -286,6 +286,23 @@ class LamSlotMag(LamSlot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from LamSlot
+        diff_list.extend(super(LamSlotMag, self).compare(other, name=name))
+        if (other.magnet is None and self.magnet is not None) or (
+            other.magnet is not None and self.magnet is None
+        ):
+            diff_list.append(name + ".magnet None mismatch")
+        elif self.magnet is not None:
+            diff_list.extend(self.magnet.compare(other.magnet, name=name + ".magnet"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LamSlotMulti.py
+++ b/pyleecan/Classes/LamSlotMulti.py
@@ -296,6 +296,32 @@ class LamSlotMulti(Lamination):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Lamination
+        diff_list.extend(super(LamSlotMulti, self).compare(other, name=name))
+        if (other.slot_list is None and self.slot_list is not None) or (
+            other.slot_list is not None and self.slot_list is None
+        ):
+            diff_list.append(name + ".slot_list None mismatch")
+        elif len(other.slot_list) != len(self.slot_list):
+            diff_list.append("len(" + name + ".slot_list)")
+        else:
+            for ii in range(len(other.slot_list)):
+                diff_list.extend(
+                    self.slot_list[ii].compare(
+                        other.slot_list[ii], name=name + ".slot_list[" + str(ii) + "]"
+                    )
+                )
+        if not array_equal(other.alpha, self.alpha):
+            diff_list.append(name + ".alpha")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LamSlotWind.py
+++ b/pyleecan/Classes/LamSlotWind.py
@@ -493,6 +493,27 @@ class LamSlotWind(LamSlot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from LamSlot
+        diff_list.extend(super(LamSlotWind, self).compare(other, name=name))
+        if other._Ksfill != self._Ksfill:
+            diff_list.append(name + ".Ksfill")
+        if (other.winding is None and self.winding is not None) or (
+            other.winding is not None and self.winding is None
+        ):
+            diff_list.append(name + ".winding None mismatch")
+        elif self.winding is not None:
+            diff_list.extend(
+                self.winding.compare(other.winding, name=name + ".winding")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LamSquirrelCage.py
+++ b/pyleecan/Classes/LamSquirrelCage.py
@@ -299,6 +299,29 @@ class LamSquirrelCage(LamSlotWind):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from LamSlotWind
+        diff_list.extend(super(LamSquirrelCage, self).compare(other, name=name))
+        if other._Hscr != self._Hscr:
+            diff_list.append(name + ".Hscr")
+        if other._Lscr != self._Lscr:
+            diff_list.append(name + ".Lscr")
+        if (other.ring_mat is None and self.ring_mat is not None) or (
+            other.ring_mat is not None and self.ring_mat is None
+        ):
+            diff_list.append(name + ".ring_mat None mismatch")
+        elif self.ring_mat is not None:
+            diff_list.extend(
+                self.ring_mat.compare(other.ring_mat, name=name + ".ring_mat")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Lamination.py
+++ b/pyleecan/Classes/Lamination.py
@@ -490,6 +490,64 @@ class Lamination(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._L1 != self._L1:
+            diff_list.append(name + ".L1")
+        if (other.mat_type is None and self.mat_type is not None) or (
+            other.mat_type is not None and self.mat_type is None
+        ):
+            diff_list.append(name + ".mat_type None mismatch")
+        elif self.mat_type is not None:
+            diff_list.extend(
+                self.mat_type.compare(other.mat_type, name=name + ".mat_type")
+            )
+        if other._Nrvd != self._Nrvd:
+            diff_list.append(name + ".Nrvd")
+        if other._Wrvd != self._Wrvd:
+            diff_list.append(name + ".Wrvd")
+        if other._Kf1 != self._Kf1:
+            diff_list.append(name + ".Kf1")
+        if other._is_internal != self._is_internal:
+            diff_list.append(name + ".is_internal")
+        if other._Rint != self._Rint:
+            diff_list.append(name + ".Rint")
+        if other._Rext != self._Rext:
+            diff_list.append(name + ".Rext")
+        if other._is_stator != self._is_stator:
+            diff_list.append(name + ".is_stator")
+        if (other.axial_vent is None and self.axial_vent is not None) or (
+            other.axial_vent is not None and self.axial_vent is None
+        ):
+            diff_list.append(name + ".axial_vent None mismatch")
+        elif len(other.axial_vent) != len(self.axial_vent):
+            diff_list.append("len(" + name + ".axial_vent)")
+        else:
+            for ii in range(len(other.axial_vent)):
+                diff_list.extend(
+                    self.axial_vent[ii].compare(
+                        other.axial_vent[ii], name=name + ".axial_vent[" + str(ii) + "]"
+                    )
+                )
+        if (other.notch is None and self.notch is not None) or (
+            other.notch is not None and self.notch is None
+        ):
+            diff_list.append(name + ".notch None mismatch")
+        elif len(other.notch) != len(self.notch):
+            diff_list.append("len(" + name + ".notch)")
+        else:
+            for ii in range(len(other.notch)):
+                diff_list.extend(
+                    self.notch[ii].compare(
+                        other.notch[ii], name=name + ".notch[" + str(ii) + "]"
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Line.py
+++ b/pyleecan/Classes/Line.py
@@ -74,6 +74,16 @@ class Line(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._label != self._label:
+            diff_list.append(name + ".label")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Loss.py
+++ b/pyleecan/Classes/Loss.py
@@ -144,6 +144,31 @@ class Loss(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._model_index != self._model_index:
+            diff_list.append(name + ".model_index")
+        if (other.model_list is None and self.model_list is not None) or (
+            other.model_list is not None and self.model_list is None
+        ):
+            diff_list.append(name + ".model_list None mismatch")
+        elif len(other.model_list) != len(self.model_list):
+            diff_list.append("len(" + name + ".model_list)")
+        else:
+            for ii in range(len(other.model_list)):
+                diff_list.extend(
+                    self.model_list[ii].compare(
+                        other.model_list[ii], name=name + ".model_list[" + str(ii) + "]"
+                    )
+                )
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LossModel.py
+++ b/pyleecan/Classes/LossModel.py
@@ -74,6 +74,16 @@ class LossModel(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LossModelBertotti.py
+++ b/pyleecan/Classes/LossModelBertotti.py
@@ -204,6 +204,35 @@ class LossModelBertotti(LossModel):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from LossModel
+        diff_list.extend(super(LossModelBertotti, self).compare(other, name=name))
+        if other._k_hy != self._k_hy:
+            diff_list.append(name + ".k_hy")
+        if other._k_ed != self._k_ed:
+            diff_list.append(name + ".k_ed")
+        if other._k_ex != self._k_ex:
+            diff_list.append(name + ".k_ex")
+        if other._alpha_hy != self._alpha_hy:
+            diff_list.append(name + ".alpha_hy")
+        if other._alpha_ed != self._alpha_ed:
+            diff_list.append(name + ".alpha_ed")
+        if other._alpha_ex != self._alpha_ex:
+            diff_list.append(name + ".alpha_ex")
+        if other._group != self._group:
+            diff_list.append(name + ".group")
+        if other._get_meshsolution != self._get_meshsolution:
+            diff_list.append(name + ".get_meshsolution")
+        if other._N0 != self._N0:
+            diff_list.append(name + ".N0")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/LossModelWinding.py
+++ b/pyleecan/Classes/LossModelWinding.py
@@ -97,6 +97,19 @@ class LossModelWinding(LossModel):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from LossModel
+        diff_list.extend(super(LossModelWinding, self).compare(other, name=name))
+        if other._temperature != self._temperature:
+            diff_list.append(name + ".temperature")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Machine.py
+++ b/pyleecan/Classes/Machine.py
@@ -455,6 +455,34 @@ class Machine(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.frame is None and self.frame is not None) or (
+            other.frame is not None and self.frame is None
+        ):
+            diff_list.append(name + ".frame None mismatch")
+        elif self.frame is not None:
+            diff_list.extend(self.frame.compare(other.frame, name=name + ".frame"))
+        if (other.shaft is None and self.shaft is not None) or (
+            other.shaft is not None and self.shaft is None
+        ):
+            diff_list.append(name + ".shaft None mismatch")
+        elif self.shaft is not None:
+            diff_list.extend(self.shaft.compare(other.shaft, name=name + ".shaft"))
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._desc != self._desc:
+            diff_list.append(name + ".desc")
+        if other._type_machine != self._type_machine:
+            diff_list.append(name + ".type_machine")
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineAsync.py
+++ b/pyleecan/Classes/MachineAsync.py
@@ -139,6 +139,17 @@ class MachineAsync(Machine):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Machine
+        diff_list.extend(super(MachineAsync, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineDFIM.py
+++ b/pyleecan/Classes/MachineDFIM.py
@@ -159,6 +159,29 @@ class MachineDFIM(MachineAsync):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from MachineAsync
+        diff_list.extend(super(MachineDFIM, self).compare(other, name=name))
+        if (other.rotor is None and self.rotor is not None) or (
+            other.rotor is not None and self.rotor is None
+        ):
+            diff_list.append(name + ".rotor None mismatch")
+        elif self.rotor is not None:
+            diff_list.extend(self.rotor.compare(other.rotor, name=name + ".rotor"))
+        if (other.stator is None and self.stator is not None) or (
+            other.stator is not None and self.stator is None
+        ):
+            diff_list.append(name + ".stator None mismatch")
+        elif self.stator is not None:
+            diff_list.extend(self.stator.compare(other.stator, name=name + ".stator"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineIPMSM.py
+++ b/pyleecan/Classes/MachineIPMSM.py
@@ -160,6 +160,29 @@ class MachineIPMSM(MachineSync):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from MachineSync
+        diff_list.extend(super(MachineIPMSM, self).compare(other, name=name))
+        if (other.rotor is None and self.rotor is not None) or (
+            other.rotor is not None and self.rotor is None
+        ):
+            diff_list.append(name + ".rotor None mismatch")
+        elif self.rotor is not None:
+            diff_list.extend(self.rotor.compare(other.rotor, name=name + ".rotor"))
+        if (other.stator is None and self.stator is not None) or (
+            other.stator is not None and self.stator is None
+        ):
+            diff_list.append(name + ".stator None mismatch")
+        elif self.stator is not None:
+            diff_list.extend(self.stator.compare(other.stator, name=name + ".stator"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineSCIM.py
+++ b/pyleecan/Classes/MachineSCIM.py
@@ -145,6 +145,17 @@ class MachineSCIM(MachineDFIM):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from MachineDFIM
+        diff_list.extend(super(MachineSCIM, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineSIPMSM.py
+++ b/pyleecan/Classes/MachineSIPMSM.py
@@ -160,6 +160,29 @@ class MachineSIPMSM(MachineSync):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from MachineSync
+        diff_list.extend(super(MachineSIPMSM, self).compare(other, name=name))
+        if (other.rotor is None and self.rotor is not None) or (
+            other.rotor is not None and self.rotor is None
+        ):
+            diff_list.append(name + ".rotor None mismatch")
+        elif self.rotor is not None:
+            diff_list.extend(self.rotor.compare(other.rotor, name=name + ".rotor"))
+        if (other.stator is None and self.stator is not None) or (
+            other.stator is not None and self.stator is None
+        ):
+            diff_list.append(name + ".stator None mismatch")
+        elif self.stator is not None:
+            diff_list.extend(self.stator.compare(other.stator, name=name + ".stator"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineSRM.py
+++ b/pyleecan/Classes/MachineSRM.py
@@ -160,6 +160,29 @@ class MachineSRM(MachineSync):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from MachineSync
+        diff_list.extend(super(MachineSRM, self).compare(other, name=name))
+        if (other.rotor is None and self.rotor is not None) or (
+            other.rotor is not None and self.rotor is None
+        ):
+            diff_list.append(name + ".rotor None mismatch")
+        elif self.rotor is not None:
+            diff_list.extend(self.rotor.compare(other.rotor, name=name + ".rotor"))
+        if (other.stator is None and self.stator is not None) or (
+            other.stator is not None and self.stator is None
+        ):
+            diff_list.append(name + ".stator None mismatch")
+        elif self.stator is not None:
+            diff_list.extend(self.stator.compare(other.stator, name=name + ".stator"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineSyRM.py
+++ b/pyleecan/Classes/MachineSyRM.py
@@ -160,6 +160,29 @@ class MachineSyRM(MachineSync):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from MachineSync
+        diff_list.extend(super(MachineSyRM, self).compare(other, name=name))
+        if (other.rotor is None and self.rotor is not None) or (
+            other.rotor is not None and self.rotor is None
+        ):
+            diff_list.append(name + ".rotor None mismatch")
+        elif self.rotor is not None:
+            diff_list.extend(self.rotor.compare(other.rotor, name=name + ".rotor"))
+        if (other.stator is None and self.stator is not None) or (
+            other.stator is not None and self.stator is None
+        ):
+            diff_list.append(name + ".stator None mismatch")
+        elif self.stator is not None:
+            diff_list.extend(self.stator.compare(other.stator, name=name + ".stator"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineSync.py
+++ b/pyleecan/Classes/MachineSync.py
@@ -121,6 +121,17 @@ class MachineSync(Machine):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Machine
+        diff_list.extend(super(MachineSync, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineUD.py
+++ b/pyleecan/Classes/MachineUD.py
@@ -156,6 +156,32 @@ class MachineUD(Machine):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Machine
+        diff_list.extend(super(MachineUD, self).compare(other, name=name))
+        if (other.lam_list is None and self.lam_list is not None) or (
+            other.lam_list is not None and self.lam_list is None
+        ):
+            diff_list.append(name + ".lam_list None mismatch")
+        elif len(other.lam_list) != len(self.lam_list):
+            diff_list.append("len(" + name + ".lam_list)")
+        else:
+            for ii in range(len(other.lam_list)):
+                diff_list.extend(
+                    self.lam_list[ii].compare(
+                        other.lam_list[ii], name=name + ".lam_list[" + str(ii) + "]"
+                    )
+                )
+        if other._is_sync != self._is_sync:
+            diff_list.append(name + ".is_sync")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MachineWRSM.py
+++ b/pyleecan/Classes/MachineWRSM.py
@@ -159,6 +159,29 @@ class MachineWRSM(MachineSync):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from MachineSync
+        diff_list.extend(super(MachineWRSM, self).compare(other, name=name))
+        if (other.rotor is None and self.rotor is not None) or (
+            other.rotor is not None and self.rotor is None
+        ):
+            diff_list.append(name + ".rotor None mismatch")
+        elif self.rotor is not None:
+            diff_list.extend(self.rotor.compare(other.rotor, name=name + ".rotor"))
+        if (other.stator is None and self.stator is not None) or (
+            other.stator is not None and self.stator is None
+        ):
+            diff_list.append(name + ".stator None mismatch")
+        elif self.stator is not None:
+            diff_list.extend(self.stator.compare(other.stator, name=name + ".stator"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MagElmer.py
+++ b/pyleecan/Classes/MagElmer.py
@@ -331,6 +331,51 @@ class MagElmer(Magnetics):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Magnetics
+        diff_list.extend(super(MagElmer, self).compare(other, name=name))
+        if other._Kmesh_fineness != self._Kmesh_fineness:
+            diff_list.append(name + ".Kmesh_fineness")
+        if other._Kgeo_fineness != self._Kgeo_fineness:
+            diff_list.append(name + ".Kgeo_fineness")
+        if other._file_name != self._file_name:
+            diff_list.append(name + ".file_name")
+        if other._FEA_dict != self._FEA_dict:
+            diff_list.append(name + ".FEA_dict")
+        if other._is_get_mesh != self._is_get_mesh:
+            diff_list.append(name + ".is_get_mesh")
+        if other._is_save_FEA != self._is_save_FEA:
+            diff_list.append(name + ".is_save_FEA")
+        if other._transform_list != self._transform_list:
+            diff_list.append(name + ".transform_list")
+        if (other.rotor_dxf is None and self.rotor_dxf is not None) or (
+            other.rotor_dxf is not None and self.rotor_dxf is None
+        ):
+            diff_list.append(name + ".rotor_dxf None mismatch")
+        elif self.rotor_dxf is not None:
+            diff_list.extend(
+                self.rotor_dxf.compare(other.rotor_dxf, name=name + ".rotor_dxf")
+            )
+        if (other.stator_dxf is None and self.stator_dxf is not None) or (
+            other.stator_dxf is not None and self.stator_dxf is None
+        ):
+            diff_list.append(name + ".stator_dxf None mismatch")
+        elif self.stator_dxf is not None:
+            diff_list.extend(
+                self.stator_dxf.compare(other.stator_dxf, name=name + ".stator_dxf")
+            )
+        if other._import_file != self._import_file:
+            diff_list.append(name + ".import_file")
+        if other._nb_worker != self._nb_worker:
+            diff_list.append(name + ".nb_worker")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MagFEMM.py
+++ b/pyleecan/Classes/MagFEMM.py
@@ -363,6 +363,59 @@ class MagFEMM(Magnetics):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Magnetics
+        diff_list.extend(super(MagFEMM, self).compare(other, name=name))
+        if other._Kmesh_fineness != self._Kmesh_fineness:
+            diff_list.append(name + ".Kmesh_fineness")
+        if other._Kgeo_fineness != self._Kgeo_fineness:
+            diff_list.append(name + ".Kgeo_fineness")
+        if other._type_calc_leakage != self._type_calc_leakage:
+            diff_list.append(name + ".type_calc_leakage")
+        if other._file_name != self._file_name:
+            diff_list.append(name + ".file_name")
+        if other._FEMM_dict_enforced != self._FEMM_dict_enforced:
+            diff_list.append(name + ".FEMM_dict_enforced")
+        if other._is_get_mesh != self._is_get_mesh:
+            diff_list.append(name + ".is_get_mesh")
+        if other._is_save_FEA != self._is_save_FEA:
+            diff_list.append(name + ".is_save_FEA")
+        if other._is_sliding_band != self._is_sliding_band:
+            diff_list.append(name + ".is_sliding_band")
+        if other._transform_list != self._transform_list:
+            diff_list.append(name + ".transform_list")
+        if (other.rotor_dxf is None and self.rotor_dxf is not None) or (
+            other.rotor_dxf is not None and self.rotor_dxf is None
+        ):
+            diff_list.append(name + ".rotor_dxf None mismatch")
+        elif self.rotor_dxf is not None:
+            diff_list.extend(
+                self.rotor_dxf.compare(other.rotor_dxf, name=name + ".rotor_dxf")
+            )
+        if (other.stator_dxf is None and self.stator_dxf is not None) or (
+            other.stator_dxf is not None and self.stator_dxf is None
+        ):
+            diff_list.append(name + ".stator_dxf None mismatch")
+        elif self.stator_dxf is not None:
+            diff_list.extend(
+                self.stator_dxf.compare(other.stator_dxf, name=name + ".stator_dxf")
+            )
+        if other._import_file != self._import_file:
+            diff_list.append(name + ".import_file")
+        if other._is_close_femm != self._is_close_femm:
+            diff_list.append(name + ".is_close_femm")
+        if other._nb_worker != self._nb_worker:
+            diff_list.append(name + ".nb_worker")
+        if other._Rag_enforced != self._Rag_enforced:
+            diff_list.append(name + ".Rag_enforced")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Magnet.py
+++ b/pyleecan/Classes/Magnet.py
@@ -98,6 +98,26 @@ class Magnet(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.mat_type is None and self.mat_type is not None) or (
+            other.mat_type is not None and self.mat_type is None
+        ):
+            diff_list.append(name + ".mat_type None mismatch")
+        elif self.mat_type is not None:
+            diff_list.extend(
+                self.mat_type.compare(other.mat_type, name=name + ".mat_type")
+            )
+        if other._type_magnetization != self._type_magnetization:
+            diff_list.append(name + ".type_magnetization")
+        if other._Lmag != self._Lmag:
+            diff_list.append(name + ".Lmag")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Magnetics.py
+++ b/pyleecan/Classes/Magnetics.py
@@ -190,6 +190,38 @@ class Magnetics(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._is_remove_slotS != self._is_remove_slotS:
+            diff_list.append(name + ".is_remove_slotS")
+        if other._is_remove_slotR != self._is_remove_slotR:
+            diff_list.append(name + ".is_remove_slotR")
+        if other._is_remove_vent != self._is_remove_vent:
+            diff_list.append(name + ".is_remove_vent")
+        if other._is_mmfs != self._is_mmfs:
+            diff_list.append(name + ".is_mmfs")
+        if other._is_mmfr != self._is_mmfr:
+            diff_list.append(name + ".is_mmfr")
+        if other._type_BH_stator != self._type_BH_stator:
+            diff_list.append(name + ".type_BH_stator")
+        if other._type_BH_rotor != self._type_BH_rotor:
+            diff_list.append(name + ".type_BH_rotor")
+        if other._is_periodicity_t != self._is_periodicity_t:
+            diff_list.append(name + ".is_periodicity_t")
+        if other._is_periodicity_a != self._is_periodicity_a:
+            diff_list.append(name + ".is_periodicity_a")
+        if other._angle_stator_shift != self._angle_stator_shift:
+            diff_list.append(name + ".angle_stator_shift")
+        if other._angle_rotor_shift != self._angle_rotor_shift:
+            diff_list.append(name + ".angle_rotor_shift")
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MatEconomical.py
+++ b/pyleecan/Classes/MatEconomical.py
@@ -82,6 +82,18 @@ class MatEconomical(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._cost_unit != self._cost_unit:
+            diff_list.append(name + ".cost_unit")
+        if other._unit_name != self._unit_name:
+            diff_list.append(name + ".unit_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MatElectrical.py
+++ b/pyleecan/Classes/MatElectrical.py
@@ -88,6 +88,20 @@ class MatElectrical(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._rho != self._rho:
+            diff_list.append(name + ".rho")
+        if other._epsr != self._epsr:
+            diff_list.append(name + ".epsr")
+        if other._alpha != self._alpha:
+            diff_list.append(name + ".alpha")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MatHT.py
+++ b/pyleecan/Classes/MatHT.py
@@ -107,6 +107,24 @@ class MatHT(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._lambda_x != self._lambda_x:
+            diff_list.append(name + ".lambda_x")
+        if other._lambda_y != self._lambda_y:
+            diff_list.append(name + ".lambda_y")
+        if other._lambda_z != self._lambda_z:
+            diff_list.append(name + ".lambda_z")
+        if other._Cp != self._Cp:
+            diff_list.append(name + ".Cp")
+        if other._alpha != self._alpha:
+            diff_list.append(name + ".alpha")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MatMagnetics.py
+++ b/pyleecan/Classes/MatMagnetics.py
@@ -167,6 +167,40 @@ class MatMagnetics(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._mur_lin != self._mur_lin:
+            diff_list.append(name + ".mur_lin")
+        if other._Hc != self._Hc:
+            diff_list.append(name + ".Hc")
+        if other._Brm20 != self._Brm20:
+            diff_list.append(name + ".Brm20")
+        if other._alpha_Br != self._alpha_Br:
+            diff_list.append(name + ".alpha_Br")
+        if other._Wlam != self._Wlam:
+            diff_list.append(name + ".Wlam")
+        if (other.BH_curve is None and self.BH_curve is not None) or (
+            other.BH_curve is not None and self.BH_curve is None
+        ):
+            diff_list.append(name + ".BH_curve None mismatch")
+        elif self.BH_curve is not None:
+            diff_list.extend(
+                self.BH_curve.compare(other.BH_curve, name=name + ".BH_curve")
+            )
+        if (other.LossData is None and self.LossData is not None) or (
+            other.LossData is not None and self.LossData is None
+        ):
+            diff_list.append(name + ".LossData None mismatch")
+        elif self.LossData is not None:
+            diff_list.extend(
+                self.LossData.compare(other.LossData, name=name + ".LossData")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MatStructural.py
+++ b/pyleecan/Classes/MatStructural.py
@@ -144,6 +144,34 @@ class MatStructural(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._rho != self._rho:
+            diff_list.append(name + ".rho")
+        if other._Ex != self._Ex:
+            diff_list.append(name + ".Ex")
+        if other._Ey != self._Ey:
+            diff_list.append(name + ".Ey")
+        if other._Ez != self._Ez:
+            diff_list.append(name + ".Ez")
+        if other._nu_xy != self._nu_xy:
+            diff_list.append(name + ".nu_xy")
+        if other._nu_xz != self._nu_xz:
+            diff_list.append(name + ".nu_xz")
+        if other._nu_yz != self._nu_yz:
+            diff_list.append(name + ".nu_yz")
+        if other._Gxz != self._Gxz:
+            diff_list.append(name + ".Gxz")
+        if other._Gxy != self._Gxy:
+            diff_list.append(name + ".Gxy")
+        if other._Gyz != self._Gyz:
+            diff_list.append(name + ".Gyz")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Material.py
+++ b/pyleecan/Classes/Material.py
@@ -159,6 +159,52 @@ class Material(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._is_isotropic != self._is_isotropic:
+            diff_list.append(name + ".is_isotropic")
+        if (other.elec is None and self.elec is not None) or (
+            other.elec is not None and self.elec is None
+        ):
+            diff_list.append(name + ".elec None mismatch")
+        elif self.elec is not None:
+            diff_list.extend(self.elec.compare(other.elec, name=name + ".elec"))
+        if (other.mag is None and self.mag is not None) or (
+            other.mag is not None and self.mag is None
+        ):
+            diff_list.append(name + ".mag None mismatch")
+        elif self.mag is not None:
+            diff_list.extend(self.mag.compare(other.mag, name=name + ".mag"))
+        if (other.struct is None and self.struct is not None) or (
+            other.struct is not None and self.struct is None
+        ):
+            diff_list.append(name + ".struct None mismatch")
+        elif self.struct is not None:
+            diff_list.extend(self.struct.compare(other.struct, name=name + ".struct"))
+        if (other.HT is None and self.HT is not None) or (
+            other.HT is not None and self.HT is None
+        ):
+            diff_list.append(name + ".HT None mismatch")
+        elif self.HT is not None:
+            diff_list.extend(self.HT.compare(other.HT, name=name + ".HT"))
+        if (other.eco is None and self.eco is not None) or (
+            other.eco is not None and self.eco is None
+        ):
+            diff_list.append(name + ".eco None mismatch")
+        elif self.eco is not None:
+            diff_list.extend(self.eco.compare(other.eco, name=name + ".eco"))
+        if other._desc != self._desc:
+            diff_list.append(name + ".desc")
+        if other._path != self._path:
+            diff_list.append(name + ".path")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Mesh.py
+++ b/pyleecan/Classes/Mesh.py
@@ -80,6 +80,18 @@ class Mesh(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._label != self._label:
+            diff_list.append(name + ".label")
+        if other._dimension != self._dimension:
+            diff_list.append(name + ".dimension")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MeshMat.py
+++ b/pyleecan/Classes/MeshMat.py
@@ -246,6 +246,34 @@ class MeshMat(Mesh):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Mesh
+        diff_list.extend(super(MeshMat, self).compare(other, name=name))
+        if (other.cell is None and self.cell is not None) or (
+            other.cell is not None and self.cell is None
+        ):
+            diff_list.append(name + ".cell None mismatch")
+        elif len(other.cell) != len(self.cell):
+            diff_list.append("len(" + name + "cell)")
+        else:
+            for key in self.cell:
+                diff_list.extend(
+                    self.cell[key].compare(other.cell[key], name=name + ".cell")
+                )
+        if (other.point is None and self.point is not None) or (
+            other.point is not None and self.point is None
+        ):
+            diff_list.append(name + ".point None mismatch")
+        elif self.point is not None:
+            diff_list.extend(self.point.compare(other.point, name=name + ".point"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MeshSolution.py
+++ b/pyleecan/Classes/MeshSolution.py
@@ -281,7 +281,7 @@ class MeshSolution(FrozenClass):
         ):
             return False
         elif other.group is None and self.group is None:
-            return True
+            pass
         elif len(other.group) != len(self.group):
             return False
         else:

--- a/pyleecan/Classes/MeshSolution.py
+++ b/pyleecan/Classes/MeshSolution.py
@@ -294,6 +294,58 @@ class MeshSolution(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._label != self._label:
+            diff_list.append(name + ".label")
+        if (other.mesh is None and self.mesh is not None) or (
+            other.mesh is not None and self.mesh is None
+        ):
+            diff_list.append(name + ".mesh None mismatch")
+        elif len(other.mesh) != len(self.mesh):
+            diff_list.append("len(" + name + ".mesh)")
+        else:
+            for ii in range(len(other.mesh)):
+                diff_list.extend(
+                    self.mesh[ii].compare(
+                        other.mesh[ii], name=name + ".mesh[" + str(ii) + "]"
+                    )
+                )
+        if other._is_same_mesh != self._is_same_mesh:
+            diff_list.append(name + ".is_same_mesh")
+        if (other.solution is None and self.solution is not None) or (
+            other.solution is not None and self.solution is None
+        ):
+            diff_list.append(name + ".solution None mismatch")
+        elif len(other.solution) != len(self.solution):
+            diff_list.append("len(" + name + ".solution)")
+        else:
+            for ii in range(len(other.solution)):
+                diff_list.extend(
+                    self.solution[ii].compare(
+                        other.solution[ii], name=name + ".solution[" + str(ii) + "]"
+                    )
+                )
+        if (other.group is None and self.group is not None) or (
+            other.group is not None and self.group is None
+        ):
+            diff_list.append(name + ".group None mismatch")
+        elif len(other.group) != len(self.group):
+            diff_list.append("len(" + name + ".group)")
+        else:
+            for key in other.group:
+                if key not in self.group or not array_equal(
+                    other.group[key], self.group[key]
+                ):
+                    diff_list.append(name + ".group[" + str(key) + "]")
+        if other._dimension != self._dimension:
+            diff_list.append(name + ".dimension")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/MeshVTK.py
+++ b/pyleecan/Classes/MeshVTK.py
@@ -275,6 +275,43 @@ class MeshVTK(Mesh):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Mesh
+        diff_list.extend(super(MeshVTK, self).compare(other, name=name))
+        if (other.mesh is None and self.mesh is not None) or (
+            other.mesh is not None and self.mesh is None
+        ):
+            diff_list.append(name + ".mesh None mismatch")
+        elif self.mesh is not None:
+            diff_list.extend(self.mesh.compare(other.mesh, name=name + ".mesh"))
+        if other._is_pyvista_mesh != self._is_pyvista_mesh:
+            diff_list.append(name + ".is_pyvista_mesh")
+        if other._format != self._format:
+            diff_list.append(name + ".format")
+        if other._path != self._path:
+            diff_list.append(name + ".path")
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if (other.surf is None and self.surf is not None) or (
+            other.surf is not None and self.surf is None
+        ):
+            diff_list.append(name + ".surf None mismatch")
+        elif self.surf is not None:
+            diff_list.extend(self.surf.compare(other.surf, name=name + ".surf"))
+        if other._is_vtk_surf != self._is_vtk_surf:
+            diff_list.append(name + ".is_vtk_surf")
+        if other._surf_path != self._surf_path:
+            diff_list.append(name + ".surf_path")
+        if other._surf_name != self._surf_name:
+            diff_list.append(name + ".surf_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Mode.py
+++ b/pyleecan/Classes/Mode.py
@@ -191,6 +191,23 @@ class Mode(SolutionMat):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from SolutionMat
+        diff_list.extend(super(Mode, self).compare(other, name=name))
+        if other._nat_freq != self._nat_freq:
+            diff_list.append(name + ".nat_freq")
+        if other._order_circ != self._order_circ:
+            diff_list.append(name + ".order_circ")
+        if other._order_long != self._order_long:
+            diff_list.append(name + ".order_long")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Notch.py
+++ b/pyleecan/Classes/Notch.py
@@ -96,6 +96,14 @@ class Notch(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/NotchEvenDist.py
+++ b/pyleecan/Classes/NotchEvenDist.py
@@ -109,6 +109,27 @@ class NotchEvenDist(Notch):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Notch
+        diff_list.extend(super(NotchEvenDist, self).compare(other, name=name))
+        if other._alpha != self._alpha:
+            diff_list.append(name + ".alpha")
+        if (other.notch_shape is None and self.notch_shape is not None) or (
+            other.notch_shape is not None and self.notch_shape is None
+        ):
+            diff_list.append(name + ".notch_shape None mismatch")
+        elif self.notch_shape is not None:
+            diff_list.extend(
+                self.notch_shape.compare(other.notch_shape, name=name + ".notch_shape")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OptiConstraint.py
+++ b/pyleecan/Classes/OptiConstraint.py
@@ -114,6 +114,22 @@ class OptiConstraint(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._type_const != self._type_const:
+            diff_list.append(name + ".type_const")
+        if other._value != self._value:
+            diff_list.append(name + ".value")
+        if other._get_variable_str != self._get_variable_str:
+            diff_list.append(name + ".get_variable")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OptiDesignVar.py
+++ b/pyleecan/Classes/OptiDesignVar.py
@@ -124,6 +124,23 @@ class OptiDesignVar(ParamExplorer):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ParamExplorer
+        diff_list.extend(super(OptiDesignVar, self).compare(other, name=name))
+        if other._type_var != self._type_var:
+            diff_list.append(name + ".type_var")
+        if other._space != self._space:
+            diff_list.append(name + ".space")
+        if other._get_value_str != self._get_value_str:
+            diff_list.append(name + ".get_value")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OptiGenAlg.py
+++ b/pyleecan/Classes/OptiGenAlg.py
@@ -162,6 +162,31 @@ class OptiGenAlg(OptiSolver):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from OptiSolver
+        diff_list.extend(super(OptiGenAlg, self).compare(other, name=name))
+        if other._selector_str != self._selector_str:
+            diff_list.append(name + ".selector")
+        if other._crossover_str != self._crossover_str:
+            diff_list.append(name + ".crossover")
+        if other._mutator_str != self._mutator_str:
+            diff_list.append(name + ".mutator")
+        if other._p_cross != self._p_cross:
+            diff_list.append(name + ".p_cross")
+        if other._p_mutate != self._p_mutate:
+            diff_list.append(name + ".p_mutate")
+        if other._size_pop != self._size_pop:
+            diff_list.append(name + ".size_pop")
+        if other._nb_gen != self._nb_gen:
+            diff_list.append(name + ".nb_gen")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OptiGenAlgNsga2Deap.py
+++ b/pyleecan/Classes/OptiGenAlgNsga2Deap.py
@@ -241,6 +241,25 @@ class OptiGenAlgNsga2Deap(OptiGenAlg):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from OptiGenAlg
+        diff_list.extend(super(OptiGenAlgNsga2Deap, self).compare(other, name=name))
+        if (other.toolbox is None and self.toolbox is not None) or (
+            other.toolbox is not None and self.toolbox is None
+        ):
+            diff_list.append(name + ".toolbox None mismatch")
+        elif self.toolbox is not None:
+            diff_list.extend(
+                self.toolbox.compare(other.toolbox, name=name + ".toolbox")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OptiObjective.py
+++ b/pyleecan/Classes/OptiObjective.py
@@ -104,6 +104,17 @@ class OptiObjective(DataKeeper):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from DataKeeper
+        diff_list.extend(super(OptiObjective, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OptiProblem.py
+++ b/pyleecan/Classes/OptiProblem.py
@@ -174,6 +174,77 @@ class OptiProblem(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.simu is None and self.simu is not None) or (
+            other.simu is not None and self.simu is None
+        ):
+            diff_list.append(name + ".simu None mismatch")
+        elif self.simu is not None:
+            diff_list.extend(self.simu.compare(other.simu, name=name + ".simu"))
+        if (other.design_var is None and self.design_var is not None) or (
+            other.design_var is not None and self.design_var is None
+        ):
+            diff_list.append(name + ".design_var None mismatch")
+        elif len(other.design_var) != len(self.design_var):
+            diff_list.append("len(" + name + ".design_var)")
+        else:
+            for ii in range(len(other.design_var)):
+                diff_list.extend(
+                    self.design_var[ii].compare(
+                        other.design_var[ii], name=name + ".design_var[" + str(ii) + "]"
+                    )
+                )
+        if (other.obj_func is None and self.obj_func is not None) or (
+            other.obj_func is not None and self.obj_func is None
+        ):
+            diff_list.append(name + ".obj_func None mismatch")
+        elif len(other.obj_func) != len(self.obj_func):
+            diff_list.append("len(" + name + ".obj_func)")
+        else:
+            for ii in range(len(other.obj_func)):
+                diff_list.extend(
+                    self.obj_func[ii].compare(
+                        other.obj_func[ii], name=name + ".obj_func[" + str(ii) + "]"
+                    )
+                )
+        if other._eval_func_str != self._eval_func_str:
+            diff_list.append(name + ".eval_func")
+        if (other.constraint is None and self.constraint is not None) or (
+            other.constraint is not None and self.constraint is None
+        ):
+            diff_list.append(name + ".constraint None mismatch")
+        elif len(other.constraint) != len(self.constraint):
+            diff_list.append("len(" + name + ".constraint)")
+        else:
+            for ii in range(len(other.constraint)):
+                diff_list.extend(
+                    self.constraint[ii].compare(
+                        other.constraint[ii], name=name + ".constraint[" + str(ii) + "]"
+                    )
+                )
+        if other._preprocessing_str != self._preprocessing_str:
+            diff_list.append(name + ".preprocessing")
+        if (other.datakeeper_list is None and self.datakeeper_list is not None) or (
+            other.datakeeper_list is not None and self.datakeeper_list is None
+        ):
+            diff_list.append(name + ".datakeeper_list None mismatch")
+        elif len(other.datakeeper_list) != len(self.datakeeper_list):
+            diff_list.append("len(" + name + ".datakeeper_list)")
+        else:
+            for ii in range(len(other.datakeeper_list)):
+                diff_list.extend(
+                    self.datakeeper_list[ii].compare(
+                        other.datakeeper_list[ii],
+                        name=name + ".datakeeper_list[" + str(ii) + "]",
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OptiSolver.py
+++ b/pyleecan/Classes/OptiSolver.py
@@ -112,6 +112,34 @@ class OptiSolver(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.problem is None and self.problem is not None) or (
+            other.problem is not None and self.problem is None
+        ):
+            diff_list.append(name + ".problem None mismatch")
+        elif self.problem is not None:
+            diff_list.extend(
+                self.problem.compare(other.problem, name=name + ".problem")
+            )
+        if (other.xoutput is None and self.xoutput is not None) or (
+            other.xoutput is not None and self.xoutput is None
+        ):
+            diff_list.append(name + ".xoutput None mismatch")
+        elif self.xoutput is not None:
+            diff_list.extend(
+                self.xoutput.compare(other.xoutput, name=name + ".xoutput")
+            )
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if other._is_keep_all_output != self._is_keep_all_output:
+            diff_list.append(name + ".is_keep_all_output")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutElec.py
+++ b/pyleecan/Classes/OutElec.py
@@ -272,6 +272,76 @@ class OutElec(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.Time is None and self.Time is not None) or (
+            other.Time is not None and self.Time is None
+        ):
+            diff_list.append(name + ".Time None mismatch")
+        elif self.Time is not None:
+            diff_list.extend(self.Time.compare(other.Time, name=name + ".Time"))
+        if (other.Angle is None and self.Angle is not None) or (
+            other.Angle is not None and self.Angle is None
+        ):
+            diff_list.append(name + ".Angle None mismatch")
+        elif self.Angle is not None:
+            diff_list.extend(self.Angle.compare(other.Angle, name=name + ".Angle"))
+        if (other.Is is None and self.Is is not None) or (
+            other.Is is not None and self.Is is None
+        ):
+            diff_list.append(name + ".Is None mismatch")
+        elif self.Is is not None:
+            diff_list.extend(self.Is.compare(other.Is, name=name + ".Is"))
+        if (other.Ir is None and self.Ir is not None) or (
+            other.Ir is not None and self.Ir is None
+        ):
+            diff_list.append(name + ".Ir None mismatch")
+        elif self.Ir is not None:
+            diff_list.extend(self.Ir.compare(other.Ir, name=name + ".Ir"))
+        if not array_equal(other.angle_rotor, self.angle_rotor):
+            diff_list.append(name + ".angle_rotor")
+        if other._N0 != self._N0:
+            diff_list.append(name + ".N0")
+        if other._angle_rotor_initial != self._angle_rotor_initial:
+            diff_list.append(name + ".angle_rotor_initial")
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if other._Tem_av_ref != self._Tem_av_ref:
+            diff_list.append(name + ".Tem_av_ref")
+        if other._Id_ref != self._Id_ref:
+            diff_list.append(name + ".Id_ref")
+        if other._Iq_ref != self._Iq_ref:
+            diff_list.append(name + ".Iq_ref")
+        if other._felec != self._felec:
+            diff_list.append(name + ".felec")
+        if other._Ud_ref != self._Ud_ref:
+            diff_list.append(name + ".Ud_ref")
+        if other._Uq_ref != self._Uq_ref:
+            diff_list.append(name + ".Uq_ref")
+        if other._Pj_losses != self._Pj_losses:
+            diff_list.append(name + ".Pj_losses")
+        if other._Pem_av_ref != self._Pem_av_ref:
+            diff_list.append(name + ".Pem_av_ref")
+        if (other.Us is None and self.Us is not None) or (
+            other.Us is not None and self.Us is None
+        ):
+            diff_list.append(name + ".Us None mismatch")
+        elif self.Us is not None:
+            diff_list.extend(self.Us.compare(other.Us, name=name + ".Us"))
+        if (other.internal is None and self.internal is not None) or (
+            other.internal is not None and self.internal is None
+        ):
+            diff_list.append(name + ".internal None mismatch")
+        elif self.internal is not None:
+            diff_list.extend(
+                self.internal.compare(other.internal, name=name + ".internal")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutForce.py
+++ b/pyleecan/Classes/OutForce.py
@@ -124,6 +124,36 @@ class OutForce(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.Time is None and self.Time is not None) or (
+            other.Time is not None and self.Time is None
+        ):
+            diff_list.append(name + ".Time None mismatch")
+        elif self.Time is not None:
+            diff_list.extend(self.Time.compare(other.Time, name=name + ".Time"))
+        if (other.Angle is None and self.Angle is not None) or (
+            other.Angle is not None and self.Angle is None
+        ):
+            diff_list.append(name + ".Angle None mismatch")
+        elif self.Angle is not None:
+            diff_list.extend(self.Angle.compare(other.Angle, name=name + ".Angle"))
+        if (other.AGSF is None and self.AGSF is not None) or (
+            other.AGSF is not None and self.AGSF is None
+        ):
+            diff_list.append(name + ".AGSF None mismatch")
+        elif self.AGSF is not None:
+            diff_list.extend(self.AGSF.compare(other.AGSF, name=name + ".AGSF"))
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if other._Rag != self._Rag:
+            diff_list.append(name + ".Rag")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutGeo.py
+++ b/pyleecan/Classes/OutGeo.py
@@ -174,6 +174,48 @@ class OutGeo(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.stator is None and self.stator is not None) or (
+            other.stator is not None and self.stator is None
+        ):
+            diff_list.append(name + ".stator None mismatch")
+        elif self.stator is not None:
+            diff_list.extend(self.stator.compare(other.stator, name=name + ".stator"))
+        if (other.rotor is None and self.rotor is not None) or (
+            other.rotor is not None and self.rotor is None
+        ):
+            diff_list.append(name + ".rotor None mismatch")
+        elif self.rotor is not None:
+            diff_list.extend(self.rotor.compare(other.rotor, name=name + ".rotor"))
+        if other._Wgap_mec != self._Wgap_mec:
+            diff_list.append(name + ".Wgap_mec")
+        if other._Wgap_mag != self._Wgap_mag:
+            diff_list.append(name + ".Wgap_mag")
+        if other._Rgap_mec != self._Rgap_mec:
+            diff_list.append(name + ".Rgap_mec")
+        if other._Lgap != self._Lgap:
+            diff_list.append(name + ".Lgap")
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if other._angle_offset_initial != self._angle_offset_initial:
+            diff_list.append(name + ".angle_offset_initial")
+        if other._rot_dir != self._rot_dir:
+            diff_list.append(name + ".rot_dir")
+        if other._per_a != self._per_a:
+            diff_list.append(name + ".per_a")
+        if other._is_antiper_a != self._is_antiper_a:
+            diff_list.append(name + ".is_antiper_a")
+        if other._per_t != self._per_t:
+            diff_list.append(name + ".per_t")
+        if other._is_antiper_t != self._is_antiper_t:
+            diff_list.append(name + ".is_antiper_t")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutGeoLam.py
+++ b/pyleecan/Classes/OutGeoLam.py
@@ -154,6 +154,34 @@ class OutGeoLam(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name_phase != self._name_phase:
+            diff_list.append(name + ".name_phase")
+        if not array_equal(other.BH_curve, self.BH_curve):
+            diff_list.append(name + ".BH_curve")
+        if other._Ksfill != self._Ksfill:
+            diff_list.append(name + ".Ksfill")
+        if other._S_slot != self._S_slot:
+            diff_list.append(name + ".S_slot")
+        if other._S_slot_wind != self._S_slot_wind:
+            diff_list.append(name + ".S_slot_wind")
+        if other._S_wind_act != self._S_wind_act:
+            diff_list.append(name + ".S_wind_act")
+        if other._per_a != self._per_a:
+            diff_list.append(name + ".per_a")
+        if other._is_antiper_a != self._is_antiper_a:
+            diff_list.append(name + ".is_antiper_a")
+        if other._per_t != self._per_t:
+            diff_list.append(name + ".per_t")
+        if other._is_antiper_t != self._is_antiper_t:
+            diff_list.append(name + ".is_antiper_t")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutInternal.py
+++ b/pyleecan/Classes/OutInternal.py
@@ -66,6 +66,14 @@ class OutInternal(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutLoss.py
+++ b/pyleecan/Classes/OutLoss.py
@@ -142,6 +142,45 @@ class OutLoss(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.loss_list is None and self.loss_list is not None) or (
+            other.loss_list is not None and self.loss_list is None
+        ):
+            diff_list.append(name + ".loss_list None mismatch")
+        elif len(other.loss_list) != len(self.loss_list):
+            diff_list.append("len(" + name + ".loss_list)")
+        else:
+            for ii in range(len(other.loss_list)):
+                diff_list.extend(
+                    self.loss_list[ii].compare(
+                        other.loss_list[ii], name=name + ".loss_list[" + str(ii) + "]"
+                    )
+                )
+        if (other.meshsol_list is None and self.meshsol_list is not None) or (
+            other.meshsol_list is not None and self.meshsol_list is None
+        ):
+            diff_list.append(name + ".meshsol_list None mismatch")
+        elif len(other.meshsol_list) != len(self.meshsol_list):
+            diff_list.append("len(" + name + ".meshsol_list)")
+        else:
+            for ii in range(len(other.meshsol_list)):
+                diff_list.extend(
+                    self.meshsol_list[ii].compare(
+                        other.meshsol_list[ii],
+                        name=name + ".meshsol_list[" + str(ii) + "]",
+                    )
+                )
+        if other._loss_index != self._loss_index:
+            diff_list.append(name + ".loss_index")
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutMag.py
+++ b/pyleecan/Classes/OutMag.py
@@ -246,6 +246,95 @@ class OutMag(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.Time is None and self.Time is not None) or (
+            other.Time is not None and self.Time is None
+        ):
+            diff_list.append(name + ".Time None mismatch")
+        elif self.Time is not None:
+            diff_list.extend(self.Time.compare(other.Time, name=name + ".Time"))
+        if (other.Angle is None and self.Angle is not None) or (
+            other.Angle is not None and self.Angle is None
+        ):
+            diff_list.append(name + ".Angle None mismatch")
+        elif self.Angle is not None:
+            diff_list.extend(self.Angle.compare(other.Angle, name=name + ".Angle"))
+        if (other.B is None and self.B is not None) or (
+            other.B is not None and self.B is None
+        ):
+            diff_list.append(name + ".B None mismatch")
+        elif self.B is not None:
+            diff_list.extend(self.B.compare(other.B, name=name + ".B"))
+        if (other.Tem is None and self.Tem is not None) or (
+            other.Tem is not None and self.Tem is None
+        ):
+            diff_list.append(name + ".Tem None mismatch")
+        elif self.Tem is not None:
+            diff_list.extend(self.Tem.compare(other.Tem, name=name + ".Tem"))
+        if other._Tem_av != self._Tem_av:
+            diff_list.append(name + ".Tem_av")
+        if other._Tem_rip_norm != self._Tem_rip_norm:
+            diff_list.append(name + ".Tem_rip_norm")
+        if other._Tem_rip_pp != self._Tem_rip_pp:
+            diff_list.append(name + ".Tem_rip_pp")
+        if (other.Phi_wind_stator is None and self.Phi_wind_stator is not None) or (
+            other.Phi_wind_stator is not None and self.Phi_wind_stator is None
+        ):
+            diff_list.append(name + ".Phi_wind_stator None mismatch")
+        elif self.Phi_wind_stator is not None:
+            diff_list.extend(
+                self.Phi_wind_stator.compare(
+                    other.Phi_wind_stator, name=name + ".Phi_wind_stator"
+                )
+            )
+        if (other.Phi_wind is None and self.Phi_wind is not None) or (
+            other.Phi_wind is not None and self.Phi_wind is None
+        ):
+            diff_list.append(name + ".Phi_wind None mismatch")
+        elif len(other.Phi_wind) != len(self.Phi_wind):
+            diff_list.append("len(" + name + "Phi_wind)")
+        else:
+            for key in self.Phi_wind:
+                diff_list.extend(
+                    self.Phi_wind[key].compare(
+                        other.Phi_wind[key], name=name + ".Phi_wind"
+                    )
+                )
+        if (other.emf is None and self.emf is not None) or (
+            other.emf is not None and self.emf is None
+        ):
+            diff_list.append(name + ".emf None mismatch")
+        elif self.emf is not None:
+            diff_list.extend(self.emf.compare(other.emf, name=name + ".emf"))
+        if (other.meshsolution is None and self.meshsolution is not None) or (
+            other.meshsolution is not None and self.meshsolution is None
+        ):
+            diff_list.append(name + ".meshsolution None mismatch")
+        elif self.meshsolution is not None:
+            diff_list.extend(
+                self.meshsolution.compare(
+                    other.meshsolution, name=name + ".meshsolution"
+                )
+            )
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if (other.internal is None and self.internal is not None) or (
+            other.internal is not None and self.internal is None
+        ):
+            diff_list.append(name + ".internal None mismatch")
+        elif self.internal is not None:
+            diff_list.extend(
+                self.internal.compare(other.internal, name=name + ".internal")
+            )
+        if other._Rag != self._Rag:
+            diff_list.append(name + ".Rag")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutMagElmer.py
+++ b/pyleecan/Classes/OutMagElmer.py
@@ -93,6 +93,19 @@ class OutMagElmer(OutInternal):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from OutInternal
+        diff_list.extend(super(OutMagElmer, self).compare(other, name=name))
+        if other._FEA_dict != self._FEA_dict:
+            diff_list.append(name + ".FEA_dict")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutMagFEMM.py
+++ b/pyleecan/Classes/OutMagFEMM.py
@@ -109,6 +109,33 @@ class OutMagFEMM(OutInternal):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from OutInternal
+        diff_list.extend(super(OutMagFEMM, self).compare(other, name=name))
+        if other._FEMM_dict != self._FEMM_dict:
+            diff_list.append(name + ".FEMM_dict")
+        if (other.handler_list is None and self.handler_list is not None) or (
+            other.handler_list is not None and self.handler_list is None
+        ):
+            diff_list.append(name + ".handler_list None mismatch")
+        elif len(other.handler_list) != len(self.handler_list):
+            diff_list.append("len(" + name + ".handler_list)")
+        else:
+            for ii in range(len(other.handler_list)):
+                diff_list.extend(
+                    self.handler_list[ii].compare(
+                        other.handler_list[ii],
+                        name=name + ".handler_list[" + str(ii) + "]",
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutPost.py
+++ b/pyleecan/Classes/OutPost.py
@@ -80,6 +80,18 @@ class OutPost(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._legend_name != self._legend_name:
+            diff_list.append(name + ".legend_name")
+        if other._line_color != self._line_color:
+            diff_list.append(name + ".line_color")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/OutStruct.py
+++ b/pyleecan/Classes/OutStruct.py
@@ -151,6 +151,62 @@ class OutStruct(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.Time is None and self.Time is not None) or (
+            other.Time is not None and self.Time is None
+        ):
+            diff_list.append(name + ".Time None mismatch")
+        elif self.Time is not None:
+            diff_list.extend(self.Time.compare(other.Time, name=name + ".Time"))
+        if (other.Angle is None and self.Angle is not None) or (
+            other.Angle is not None and self.Angle is None
+        ):
+            diff_list.append(name + ".Angle None mismatch")
+        elif self.Angle is not None:
+            diff_list.extend(self.Angle.compare(other.Angle, name=name + ".Angle"))
+        if other._Nt_tot != self._Nt_tot:
+            diff_list.append(name + ".Nt_tot")
+        if other._Na_tot != self._Na_tot:
+            diff_list.append(name + ".Na_tot")
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if (other.Yr is None and self.Yr is not None) or (
+            other.Yr is not None and self.Yr is None
+        ):
+            diff_list.append(name + ".Yr None mismatch")
+        elif self.Yr is not None:
+            diff_list.extend(self.Yr.compare(other.Yr, name=name + ".Yr"))
+        if (other.Vr is None and self.Vr is not None) or (
+            other.Vr is not None and self.Vr is None
+        ):
+            diff_list.append(name + ".Vr None mismatch")
+        elif self.Vr is not None:
+            diff_list.extend(self.Vr.compare(other.Vr, name=name + ".Vr"))
+        if (other.Ar is None and self.Ar is not None) or (
+            other.Ar is not None and self.Ar is None
+        ):
+            diff_list.append(name + ".Ar None mismatch")
+        elif self.Ar is not None:
+            diff_list.extend(self.Ar.compare(other.Ar, name=name + ".Ar"))
+        if (other.meshsolution is None and self.meshsolution is not None) or (
+            other.meshsolution is not None and self.meshsolution is None
+        ):
+            diff_list.append(name + ".meshsolution None mismatch")
+        elif self.meshsolution is not None:
+            diff_list.extend(
+                self.meshsolution.compare(
+                    other.meshsolution, name=name + ".meshsolution"
+                )
+            )
+        if other._FEA_dict != self._FEA_dict:
+            diff_list.append(name + ".FEA_dict")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Output.py
+++ b/pyleecan/Classes/Output.py
@@ -416,6 +416,66 @@ class Output(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if (other.simu is None and self.simu is not None) or (
+            other.simu is not None and self.simu is None
+        ):
+            diff_list.append(name + ".simu None mismatch")
+        elif self.simu is not None:
+            diff_list.extend(self.simu.compare(other.simu, name=name + ".simu"))
+        if other._path_result != self._path_result:
+            diff_list.append(name + ".path_result")
+        if (other.geo is None and self.geo is not None) or (
+            other.geo is not None and self.geo is None
+        ):
+            diff_list.append(name + ".geo None mismatch")
+        elif self.geo is not None:
+            diff_list.extend(self.geo.compare(other.geo, name=name + ".geo"))
+        if (other.elec is None and self.elec is not None) or (
+            other.elec is not None and self.elec is None
+        ):
+            diff_list.append(name + ".elec None mismatch")
+        elif self.elec is not None:
+            diff_list.extend(self.elec.compare(other.elec, name=name + ".elec"))
+        if (other.mag is None and self.mag is not None) or (
+            other.mag is not None and self.mag is None
+        ):
+            diff_list.append(name + ".mag None mismatch")
+        elif self.mag is not None:
+            diff_list.extend(self.mag.compare(other.mag, name=name + ".mag"))
+        if (other.struct is None and self.struct is not None) or (
+            other.struct is not None and self.struct is None
+        ):
+            diff_list.append(name + ".struct None mismatch")
+        elif self.struct is not None:
+            diff_list.extend(self.struct.compare(other.struct, name=name + ".struct"))
+        if (other.post is None and self.post is not None) or (
+            other.post is not None and self.post is None
+        ):
+            diff_list.append(name + ".post None mismatch")
+        elif self.post is not None:
+            diff_list.extend(self.post.compare(other.post, name=name + ".post"))
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if (other.force is None and self.force is not None) or (
+            other.force is not None and self.force is None
+        ):
+            diff_list.append(name + ".force None mismatch")
+        elif self.force is not None:
+            diff_list.extend(self.force.compare(other.force, name=name + ".force"))
+        if (other.loss is None and self.loss is not None) or (
+            other.loss is not None and self.loss is None
+        ):
+            diff_list.append(name + ".loss None mismatch")
+        elif self.loss is not None:
+            diff_list.extend(self.loss.compare(other.loss, name=name + ".loss"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ParamExplorer.py
+++ b/pyleecan/Classes/ParamExplorer.py
@@ -125,6 +125,22 @@ class ParamExplorer(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._symbol != self._symbol:
+            diff_list.append(name + ".symbol")
+        if other._unit != self._unit:
+            diff_list.append(name + ".unit")
+        if other._setter_str != self._setter_str:
+            diff_list.append(name + ".setter")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ParamExplorerSet.py
+++ b/pyleecan/Classes/ParamExplorerSet.py
@@ -141,6 +141,19 @@ class ParamExplorerSet(ParamExplorer):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ParamExplorer
+        diff_list.extend(super(ParamExplorerSet, self).compare(other, name=name))
+        if other._value != self._value:
+            diff_list.append(name + ".value")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/PointMat.py
+++ b/pyleecan/Classes/PointMat.py
@@ -173,6 +173,22 @@ class PointMat(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if not array_equal(other.coordinate, self.coordinate):
+            diff_list.append(name + ".coordinate")
+        if other._nb_pt != self._nb_pt:
+            diff_list.append(name + ".nb_pt")
+        if other._delta != self._delta:
+            diff_list.append(name + ".delta")
+        if not array_equal(other.indice, self.indice):
+            diff_list.append(name + ".indice")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/PolarArc.py
+++ b/pyleecan/Classes/PolarArc.py
@@ -226,6 +226,21 @@ class PolarArc(Surface):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Surface
+        diff_list.extend(super(PolarArc, self).compare(other, name=name))
+        if other._angle != self._angle:
+            diff_list.append(name + ".angle")
+        if other._height != self._height:
+            diff_list.append(name + ".height")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Post.py
+++ b/pyleecan/Classes/Post.py
@@ -64,6 +64,14 @@ class Post(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/PostFunction.py
+++ b/pyleecan/Classes/PostFunction.py
@@ -86,6 +86,19 @@ class PostFunction(Post):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Post
+        diff_list.extend(super(PostFunction, self).compare(other, name=name))
+        if other._run_str != self._run_str:
+            diff_list.append(name + ".run")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/PostMethod.py
+++ b/pyleecan/Classes/PostMethod.py
@@ -87,6 +87,17 @@ class PostMethod(Post):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Post
+        diff_list.extend(super(PostMethod, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/PostPlot.py
+++ b/pyleecan/Classes/PostPlot.py
@@ -131,6 +131,27 @@ class PostPlot(PostMethod):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from PostMethod
+        diff_list.extend(super(PostPlot, self).compare(other, name=name))
+        if other._method != self._method:
+            diff_list.append(name + ".method")
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._param_list != self._param_list:
+            diff_list.append(name + ".param_list")
+        if other._param_dict != self._param_dict:
+            diff_list.append(name + ".param_dict")
+        if other._save_format != self._save_format:
+            diff_list.append(name + ".save_format")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/RefCell.py
+++ b/pyleecan/Classes/RefCell.py
@@ -93,6 +93,16 @@ class RefCell(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._epsilon != self._epsilon:
+            diff_list.append(name + ".epsilon")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/RefLine3.py
+++ b/pyleecan/Classes/RefLine3.py
@@ -169,6 +169,17 @@ class RefLine3(RefCell):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from RefCell
+        diff_list.extend(super(RefLine3, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/RefQuad4.py
+++ b/pyleecan/Classes/RefQuad4.py
@@ -169,6 +169,17 @@ class RefQuad4(RefCell):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from RefCell
+        diff_list.extend(super(RefQuad4, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/RefQuad9.py
+++ b/pyleecan/Classes/RefQuad9.py
@@ -169,6 +169,17 @@ class RefQuad9(RefCell):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from RefCell
+        diff_list.extend(super(RefQuad9, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/RefSegmentP1.py
+++ b/pyleecan/Classes/RefSegmentP1.py
@@ -189,6 +189,17 @@ class RefSegmentP1(RefCell):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from RefCell
+        diff_list.extend(super(RefSegmentP1, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/RefTriangle3.py
+++ b/pyleecan/Classes/RefTriangle3.py
@@ -205,6 +205,17 @@ class RefTriangle3(RefCell):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from RefCell
+        diff_list.extend(super(RefTriangle3, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/RefTriangle6.py
+++ b/pyleecan/Classes/RefTriangle6.py
@@ -173,6 +173,17 @@ class RefTriangle6(RefCell):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from RefCell
+        diff_list.extend(super(RefTriangle6, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ScalarProduct.py
+++ b/pyleecan/Classes/ScalarProduct.py
@@ -66,6 +66,14 @@ class ScalarProduct(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/ScalarProductL2.py
+++ b/pyleecan/Classes/ScalarProductL2.py
@@ -90,6 +90,17 @@ class ScalarProductL2(ScalarProduct):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from ScalarProduct
+        diff_list.extend(super(ScalarProductL2, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Section.py
+++ b/pyleecan/Classes/Section.py
@@ -258,6 +258,27 @@ class Section(Elmer):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Elmer
+        diff_list.extend(super(Section, self).compare(other, name=name))
+        if other._section != self._section:
+            diff_list.append(name + ".section")
+        if other._id != self._id:
+            diff_list.append(name + ".id")
+        if other._comment != self._comment:
+            diff_list.append(name + ".comment")
+        if other.__statements != self.__statements:
+            diff_list.append(name + "._statements")
+        if other.__comments != self.__comments:
+            diff_list.append(name + "._comments")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Segment.py
+++ b/pyleecan/Classes/Segment.py
@@ -316,6 +316,21 @@ class Segment(Line):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Line
+        diff_list.extend(super(Segment, self).compare(other, name=name))
+        if other._begin != self._begin:
+            diff_list.append(name + ".begin")
+        if other._end != self._end:
+            diff_list.append(name + ".end")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Shaft.py
+++ b/pyleecan/Classes/Shaft.py
@@ -141,6 +141,26 @@ class Shaft(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._Lshaft != self._Lshaft:
+            diff_list.append(name + ".Lshaft")
+        if (other.mat_type is None and self.mat_type is not None) or (
+            other.mat_type is not None and self.mat_type is None
+        ):
+            diff_list.append(name + ".mat_type None mismatch")
+        elif self.mat_type is not None:
+            diff_list.extend(
+                self.mat_type.compare(other.mat_type, name=name + ".mat_type")
+            )
+        if other._Drsh != self._Drsh:
+            diff_list.append(name + ".Drsh")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Simu1.py
+++ b/pyleecan/Classes/Simu1.py
@@ -192,6 +192,47 @@ class Simu1(Simulation):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Simulation
+        diff_list.extend(super(Simu1, self).compare(other, name=name))
+        if (other.elec is None and self.elec is not None) or (
+            other.elec is not None and self.elec is None
+        ):
+            diff_list.append(name + ".elec None mismatch")
+        elif self.elec is not None:
+            diff_list.extend(self.elec.compare(other.elec, name=name + ".elec"))
+        if (other.mag is None and self.mag is not None) or (
+            other.mag is not None and self.mag is None
+        ):
+            diff_list.append(name + ".mag None mismatch")
+        elif self.mag is not None:
+            diff_list.extend(self.mag.compare(other.mag, name=name + ".mag"))
+        if (other.struct is None and self.struct is not None) or (
+            other.struct is not None and self.struct is None
+        ):
+            diff_list.append(name + ".struct None mismatch")
+        elif self.struct is not None:
+            diff_list.extend(self.struct.compare(other.struct, name=name + ".struct"))
+        if (other.force is None and self.force is not None) or (
+            other.force is not None and self.force is None
+        ):
+            diff_list.append(name + ".force None mismatch")
+        elif self.force is not None:
+            diff_list.extend(self.force.compare(other.force, name=name + ".force"))
+        if (other.loss is None and self.loss is not None) or (
+            other.loss is not None and self.loss is None
+        ):
+            diff_list.append(name + ".loss None mismatch")
+        elif self.loss is not None:
+            diff_list.extend(self.loss.compare(other.loss, name=name + ".loss"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Simulation.py
+++ b/pyleecan/Classes/Simulation.py
@@ -194,6 +194,60 @@ class Simulation(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._desc != self._desc:
+            diff_list.append(name + ".desc")
+        if (other.machine is None and self.machine is not None) or (
+            other.machine is not None and self.machine is None
+        ):
+            diff_list.append(name + ".machine None mismatch")
+        elif self.machine is not None:
+            diff_list.extend(
+                self.machine.compare(other.machine, name=name + ".machine")
+            )
+        if (other.input is None and self.input is not None) or (
+            other.input is not None and self.input is None
+        ):
+            diff_list.append(name + ".input None mismatch")
+        elif self.input is not None:
+            diff_list.extend(self.input.compare(other.input, name=name + ".input"))
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        if (other.var_simu is None and self.var_simu is not None) or (
+            other.var_simu is not None and self.var_simu is None
+        ):
+            diff_list.append(name + ".var_simu None mismatch")
+        elif self.var_simu is not None:
+            diff_list.extend(
+                self.var_simu.compare(other.var_simu, name=name + ".var_simu")
+            )
+        if (other.postproc_list is None and self.postproc_list is not None) or (
+            other.postproc_list is not None and self.postproc_list is None
+        ):
+            diff_list.append(name + ".postproc_list None mismatch")
+        elif len(other.postproc_list) != len(self.postproc_list):
+            diff_list.append("len(" + name + ".postproc_list)")
+        else:
+            for ii in range(len(other.postproc_list)):
+                diff_list.extend(
+                    self.postproc_list[ii].compare(
+                        other.postproc_list[ii],
+                        name=name + ".postproc_list[" + str(ii) + "]",
+                    )
+                )
+        if other._index != self._index:
+            diff_list.append(name + ".index")
+        if other._path_result != self._path_result:
+            diff_list.append(name + ".path_result")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Slot.py
+++ b/pyleecan/Classes/Slot.py
@@ -386,6 +386,16 @@ class Slot(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._Zs != self._Zs:
+            diff_list.append(name + ".Zs")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Slot19.py
+++ b/pyleecan/Classes/Slot19.py
@@ -221,6 +221,25 @@ class Slot19(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(Slot19, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._Wx_is_rad != self._Wx_is_rad:
+            diff_list.append(name + ".Wx_is_rad")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotCirc.py
+++ b/pyleecan/Classes/SlotCirc.py
@@ -219,6 +219,21 @@ class SlotCirc(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotCirc, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotDC.py
+++ b/pyleecan/Classes/SlotDC.py
@@ -283,6 +283,33 @@ class SlotDC(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotDC, self).compare(other, name=name))
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._D1 != self._D1:
+            diff_list.append(name + ".D1")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._D2 != self._D2:
+            diff_list.append(name + ".D2")
+        if other._H3 != self._H3:
+            diff_list.append(name + ".H3")
+        if other._R3 != self._R3:
+            diff_list.append(name + ".R3")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotM10.py
+++ b/pyleecan/Classes/SlotM10.py
@@ -271,6 +271,25 @@ class SlotM10(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotM10, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._Wmag != self._Wmag:
+            diff_list.append(name + ".Wmag")
+        if other._Hmag != self._Hmag:
+            diff_list.append(name + ".Hmag")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotM11.py
+++ b/pyleecan/Classes/SlotM11.py
@@ -271,6 +271,25 @@ class SlotM11(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotM11, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._Wmag != self._Wmag:
+            diff_list.append(name + ".Wmag")
+        if other._Hmag != self._Hmag:
+            diff_list.append(name + ".Hmag")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotM12.py
+++ b/pyleecan/Classes/SlotM12.py
@@ -271,6 +271,25 @@ class SlotM12(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotM12, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._Wmag != self._Wmag:
+            diff_list.append(name + ".Wmag")
+        if other._Hmag != self._Hmag:
+            diff_list.append(name + ".Hmag")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotM13.py
+++ b/pyleecan/Classes/SlotM13.py
@@ -278,6 +278,27 @@ class SlotM13(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotM13, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._Wmag != self._Wmag:
+            diff_list.append(name + ".Wmag")
+        if other._Hmag != self._Hmag:
+            diff_list.append(name + ".Hmag")
+        if other._Rtopm != self._Rtopm:
+            diff_list.append(name + ".Rtopm")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotM14.py
+++ b/pyleecan/Classes/SlotM14.py
@@ -278,6 +278,27 @@ class SlotM14(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotM14, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._Wmag != self._Wmag:
+            diff_list.append(name + ".Wmag")
+        if other._Hmag != self._Hmag:
+            diff_list.append(name + ".Hmag")
+        if other._Rtopm != self._Rtopm:
+            diff_list.append(name + ".Rtopm")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotM15.py
+++ b/pyleecan/Classes/SlotM15.py
@@ -278,6 +278,27 @@ class SlotM15(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotM15, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._Wmag != self._Wmag:
+            diff_list.append(name + ".Wmag")
+        if other._Hmag != self._Hmag:
+            diff_list.append(name + ".Hmag")
+        if other._Rtopm != self._Rtopm:
+            diff_list.append(name + ".Rtopm")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotM16.py
+++ b/pyleecan/Classes/SlotM16.py
@@ -271,6 +271,25 @@ class SlotM16(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotM16, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotUD.py
+++ b/pyleecan/Classes/SlotUD.py
@@ -180,6 +180,36 @@ class SlotUD(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotUD, self).compare(other, name=name))
+        if (other.line_list is None and self.line_list is not None) or (
+            other.line_list is not None and self.line_list is None
+        ):
+            diff_list.append(name + ".line_list None mismatch")
+        elif len(other.line_list) != len(self.line_list):
+            diff_list.append("len(" + name + ".line_list)")
+        else:
+            for ii in range(len(other.line_list)):
+                diff_list.extend(
+                    self.line_list[ii].compare(
+                        other.line_list[ii], name=name + ".line_list[" + str(ii) + "]"
+                    )
+                )
+        if other._wind_begin_index != self._wind_begin_index:
+            diff_list.append(name + ".wind_begin_index")
+        if other._wind_end_index != self._wind_end_index:
+            diff_list.append(name + ".wind_end_index")
+        if other._type_line_wind != self._type_line_wind:
+            diff_list.append(name + ".type_line_wind")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotUD2.py
+++ b/pyleecan/Classes/SlotUD2.py
@@ -151,6 +151,38 @@ class SlotUD2(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotUD2, self).compare(other, name=name))
+        if (other.line_list is None and self.line_list is not None) or (
+            other.line_list is not None and self.line_list is None
+        ):
+            diff_list.append(name + ".line_list None mismatch")
+        elif len(other.line_list) != len(self.line_list):
+            diff_list.append("len(" + name + ".line_list)")
+        else:
+            for ii in range(len(other.line_list)):
+                diff_list.extend(
+                    self.line_list[ii].compare(
+                        other.line_list[ii], name=name + ".line_list[" + str(ii) + "]"
+                    )
+                )
+        if (other.active_surf is None and self.active_surf is not None) or (
+            other.active_surf is not None and self.active_surf is None
+        ):
+            diff_list.append(name + ".active_surf None mismatch")
+        elif self.active_surf is not None:
+            diff_list.extend(
+                self.active_surf.compare(other.active_surf, name=name + ".active_surf")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW10.py
+++ b/pyleecan/Classes/SlotW10.py
@@ -323,6 +323,31 @@ class SlotW10(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW10, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._H1_is_rad != self._H1_is_rad:
+            diff_list.append(name + ".H1_is_rad")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW11.py
+++ b/pyleecan/Classes/SlotW11.py
@@ -312,6 +312,33 @@ class SlotW11(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW11, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H1_is_rad != self._H1_is_rad:
+            diff_list.append(name + ".H1_is_rad")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW12.py
+++ b/pyleecan/Classes/SlotW12.py
@@ -263,6 +263,25 @@ class SlotW12(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW12, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        if other._R2 != self._R2:
+            diff_list.append(name + ".R2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW13.py
+++ b/pyleecan/Classes/SlotW13.py
@@ -330,6 +330,33 @@ class SlotW13(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW13, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H1_is_rad != self._H1_is_rad:
+            diff_list.append(name + ".H1_is_rad")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW14.py
+++ b/pyleecan/Classes/SlotW14.py
@@ -277,6 +277,27 @@ class SlotW14(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW14, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H3 != self._H3:
+            diff_list.append(name + ".H3")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW15.py
+++ b/pyleecan/Classes/SlotW15.py
@@ -274,6 +274,31 @@ class SlotW15(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW15, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        if other._R2 != self._R2:
+            diff_list.append(name + ".R2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW16.py
+++ b/pyleecan/Classes/SlotW16.py
@@ -260,6 +260,27 @@ class SlotW16(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW16, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW21.py
+++ b/pyleecan/Classes/SlotW21.py
@@ -323,6 +323,31 @@ class SlotW21(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW21, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H1_is_rad != self._H1_is_rad:
+            diff_list.append(name + ".H1_is_rad")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW22.py
+++ b/pyleecan/Classes/SlotW22.py
@@ -288,6 +288,25 @@ class SlotW22(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW22, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW23.py
+++ b/pyleecan/Classes/SlotW23.py
@@ -337,6 +337,35 @@ class SlotW23(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW23, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H1_is_rad != self._H1_is_rad:
+            diff_list.append(name + ".H1_is_rad")
+        if other._is_cstt_tooth != self._is_cstt_tooth:
+            diff_list.append(name + ".is_cstt_tooth")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW24.py
+++ b/pyleecan/Classes/SlotW24.py
@@ -266,6 +266,21 @@ class SlotW24(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW24, self).compare(other, name=name))
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW25.py
+++ b/pyleecan/Classes/SlotW25.py
@@ -287,6 +287,25 @@ class SlotW25(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW25, self).compare(other, name=name))
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W4 != self._W4:
+            diff_list.append(name + ".W4")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW26.py
+++ b/pyleecan/Classes/SlotW26.py
@@ -277,6 +277,27 @@ class SlotW26(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW26, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        if other._R2 != self._R2:
+            diff_list.append(name + ".R2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW27.py
+++ b/pyleecan/Classes/SlotW27.py
@@ -299,6 +299,33 @@ class SlotW27(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW27, self).compare(other, name=name))
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._is_trap_wind != self._is_trap_wind:
+            diff_list.append(name + ".is_trap_wind")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW28.py
+++ b/pyleecan/Classes/SlotW28.py
@@ -260,6 +260,27 @@ class SlotW28(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW28, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        if other._H3 != self._H3:
+            diff_list.append(name + ".H3")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW29.py
+++ b/pyleecan/Classes/SlotW29.py
@@ -301,6 +301,29 @@ class SlotW29(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW29, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW60.py
+++ b/pyleecan/Classes/SlotW60.py
@@ -299,6 +299,33 @@ class SlotW60(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW60, self).compare(other, name=name))
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._R1 != self._R1:
+            diff_list.append(name + ".R1")
+        if other._H3 != self._H3:
+            diff_list.append(name + ".H3")
+        if other._H4 != self._H4:
+            diff_list.append(name + ".H4")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SlotW61.py
+++ b/pyleecan/Classes/SlotW61.py
@@ -306,6 +306,35 @@ class SlotW61(Slot):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Slot
+        diff_list.extend(super(SlotW61, self).compare(other, name=name))
+        if other._W0 != self._W0:
+            diff_list.append(name + ".W0")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._H1 != self._H1:
+            diff_list.append(name + ".H1")
+        if other._H2 != self._H2:
+            diff_list.append(name + ".H2")
+        if other._H3 != self._H3:
+            diff_list.append(name + ".H3")
+        if other._H4 != self._H4:
+            diff_list.append(name + ".H4")
+        if other._W3 != self._W3:
+            diff_list.append(name + ".W3")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Solution.py
+++ b/pyleecan/Classes/Solution.py
@@ -93,6 +93,20 @@ class Solution(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._type_cell != self._type_cell:
+            diff_list.append(name + ".type_cell")
+        if other._label != self._label:
+            diff_list.append(name + ".label")
+        if other._dimension != self._dimension:
+            diff_list.append(name + ".dimension")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SolutionData.py
+++ b/pyleecan/Classes/SolutionData.py
@@ -144,6 +144,23 @@ class SolutionData(Solution):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Solution
+        diff_list.extend(super(SolutionData, self).compare(other, name=name))
+        if (other.field is None and self.field is not None) or (
+            other.field is not None and self.field is None
+        ):
+            diff_list.append(name + ".field None mismatch")
+        elif self.field is not None:
+            diff_list.extend(self.field.compare(other.field, name=name + ".field"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SolutionMat.py
+++ b/pyleecan/Classes/SolutionMat.py
@@ -186,6 +186,25 @@ class SolutionMat(Solution):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Solution
+        diff_list.extend(super(SolutionMat, self).compare(other, name=name))
+        if not array_equal(other.field, self.field):
+            diff_list.append(name + ".field")
+        if not array_equal(other.indice, self.indice):
+            diff_list.append(name + ".indice")
+        if other._axis_name != self._axis_name:
+            diff_list.append(name + ".axis_name")
+        if other._axis_size != self._axis_size:
+            diff_list.append(name + ".axis_size")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SolutionVector.py
+++ b/pyleecan/Classes/SolutionVector.py
@@ -145,6 +145,23 @@ class SolutionVector(Solution):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Solution
+        diff_list.extend(super(SolutionVector, self).compare(other, name=name))
+        if (other.field is None and self.field is not None) or (
+            other.field is not None and self.field is None
+        ):
+            diff_list.append(name + ".field None mismatch")
+        elif self.field is not None:
+            diff_list.extend(self.field.compare(other.field, name=name + ".field"))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SolverInputFile.py
+++ b/pyleecan/Classes/SolverInputFile.py
@@ -102,6 +102,19 @@ class SolverInputFile(Elmer):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Elmer
+        diff_list.extend(super(SolverInputFile, self).compare(other, name=name))
+        if other._sections != self._sections:
+            diff_list.append(name + ".sections")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/StructElmer.py
+++ b/pyleecan/Classes/StructElmer.py
@@ -243,6 +243,31 @@ class StructElmer(Structural):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Structural
+        diff_list.extend(super(StructElmer, self).compare(other, name=name))
+        if other._Kmesh_fineness != self._Kmesh_fineness:
+            diff_list.append(name + ".Kmesh_fineness")
+        if other._path_name != self._path_name:
+            diff_list.append(name + ".path_name")
+        if other._FEA_dict_enforced != self._FEA_dict_enforced:
+            diff_list.append(name + ".FEA_dict_enforced")
+        if other._is_get_mesh != self._is_get_mesh:
+            diff_list.append(name + ".is_get_mesh")
+        if other._is_save_FEA != self._is_save_FEA:
+            diff_list.append(name + ".is_save_FEA")
+        if other._transform_list != self._transform_list:
+            diff_list.append(name + ".transform_list")
+        if other._include_magnets != self._include_magnets:
+            diff_list.append(name + ".include_magnets")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Structural.py
+++ b/pyleecan/Classes/Structural.py
@@ -108,6 +108,16 @@ class Structural(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._logger_name != self._logger_name:
+            diff_list.append(name + ".logger_name")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SurfLine.py
+++ b/pyleecan/Classes/SurfLine.py
@@ -241,6 +241,30 @@ class SurfLine(Surface):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Surface
+        diff_list.extend(super(SurfLine, self).compare(other, name=name))
+        if (other.line_list is None and self.line_list is not None) or (
+            other.line_list is not None and self.line_list is None
+        ):
+            diff_list.append(name + ".line_list None mismatch")
+        elif len(other.line_list) != len(self.line_list):
+            diff_list.append("len(" + name + ".line_list)")
+        else:
+            for ii in range(len(other.line_list)):
+                diff_list.extend(
+                    self.line_list[ii].compare(
+                        other.line_list[ii], name=name + ".line_list[" + str(ii) + "]"
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/SurfRing.py
+++ b/pyleecan/Classes/SurfRing.py
@@ -255,6 +255,33 @@ class SurfRing(Surface):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Surface
+        diff_list.extend(super(SurfRing, self).compare(other, name=name))
+        if (other.out_surf is None and self.out_surf is not None) or (
+            other.out_surf is not None and self.out_surf is None
+        ):
+            diff_list.append(name + ".out_surf None mismatch")
+        elif self.out_surf is not None:
+            diff_list.extend(
+                self.out_surf.compare(other.out_surf, name=name + ".out_surf")
+            )
+        if (other.in_surf is None and self.in_surf is not None) or (
+            other.in_surf is not None and self.in_surf is None
+        ):
+            diff_list.append(name + ".in_surf None mismatch")
+        elif self.in_surf is not None:
+            diff_list.extend(
+                self.in_surf.compare(other.in_surf, name=name + ".in_surf")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Surface.py
+++ b/pyleecan/Classes/Surface.py
@@ -142,6 +142,18 @@ class Surface(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._point_ref != self._point_ref:
+            diff_list.append(name + ".point_ref")
+        if other._label != self._label:
+            diff_list.append(name + ".label")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Trapeze.py
+++ b/pyleecan/Classes/Trapeze.py
@@ -228,6 +228,23 @@ class Trapeze(Surface):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Surface
+        diff_list.extend(super(Trapeze, self).compare(other, name=name))
+        if other._height != self._height:
+            diff_list.append(name + ".height")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Unit.py
+++ b/pyleecan/Classes/Unit.py
@@ -173,6 +173,20 @@ class Unit(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._unit_m != self._unit_m:
+            diff_list.append(name + ".unit_m")
+        if other._unit_rad != self._unit_rad:
+            diff_list.append(name + ".unit_rad")
+        if other._unit_m2 != self._unit_m2:
+            diff_list.append(name + ".unit_m2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/VarLoad.py
+++ b/pyleecan/Classes/VarLoad.py
@@ -176,6 +176,17 @@ class VarLoad(VarSimu):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from VarSimu
+        diff_list.extend(super(VarLoad, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/VarLoadCurrent.py
+++ b/pyleecan/Classes/VarLoadCurrent.py
@@ -248,6 +248,25 @@ class VarLoadCurrent(VarLoad):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from VarLoad
+        diff_list.extend(super(VarLoadCurrent, self).compare(other, name=name))
+        if not array_equal(other.OP_matrix, self.OP_matrix):
+            diff_list.append(name + ".OP_matrix")
+        if other._type_OP_matrix != self._type_OP_matrix:
+            diff_list.append(name + ".type_OP_matrix")
+        if other._is_torque != self._is_torque:
+            diff_list.append(name + ".is_torque")
+        if other._is_power != self._is_power:
+            diff_list.append(name + ".is_power")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/VarParam.py
+++ b/pyleecan/Classes/VarParam.py
@@ -190,6 +190,31 @@ class VarParam(VarSimu):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from VarSimu
+        diff_list.extend(super(VarParam, self).compare(other, name=name))
+        if (
+            other.paramexplorer_list is None and self.paramexplorer_list is not None
+        ) or (other.paramexplorer_list is not None and self.paramexplorer_list is None):
+            diff_list.append(name + ".paramexplorer_list None mismatch")
+        elif len(other.paramexplorer_list) != len(self.paramexplorer_list):
+            diff_list.append("len(" + name + ".paramexplorer_list)")
+        else:
+            for ii in range(len(other.paramexplorer_list)):
+                diff_list.extend(
+                    self.paramexplorer_list[ii].compare(
+                        other.paramexplorer_list[ii],
+                        name=name + ".paramexplorer_list[" + str(ii) + "]",
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/VarSimu.py
+++ b/pyleecan/Classes/VarSimu.py
@@ -253,6 +253,94 @@ class VarSimu(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._name != self._name:
+            diff_list.append(name + ".name")
+        if other._desc != self._desc:
+            diff_list.append(name + ".desc")
+        if (other.datakeeper_list is None and self.datakeeper_list is not None) or (
+            other.datakeeper_list is not None and self.datakeeper_list is None
+        ):
+            diff_list.append(name + ".datakeeper_list None mismatch")
+        elif len(other.datakeeper_list) != len(self.datakeeper_list):
+            diff_list.append("len(" + name + ".datakeeper_list)")
+        else:
+            for ii in range(len(other.datakeeper_list)):
+                diff_list.extend(
+                    self.datakeeper_list[ii].compare(
+                        other.datakeeper_list[ii],
+                        name=name + ".datakeeper_list[" + str(ii) + "]",
+                    )
+                )
+        if other._is_keep_all_output != self._is_keep_all_output:
+            diff_list.append(name + ".is_keep_all_output")
+        if other._stop_if_error != self._stop_if_error:
+            diff_list.append(name + ".stop_if_error")
+        if other._ref_simu_index != self._ref_simu_index:
+            diff_list.append(name + ".ref_simu_index")
+        if other._nb_simu != self._nb_simu:
+            diff_list.append(name + ".nb_simu")
+        if other._is_reuse_femm_file != self._is_reuse_femm_file:
+            diff_list.append(name + ".is_reuse_femm_file")
+        if (other.postproc_list is None and self.postproc_list is not None) or (
+            other.postproc_list is not None and self.postproc_list is None
+        ):
+            diff_list.append(name + ".postproc_list None mismatch")
+        elif len(other.postproc_list) != len(self.postproc_list):
+            diff_list.append("len(" + name + ".postproc_list)")
+        else:
+            for ii in range(len(other.postproc_list)):
+                diff_list.extend(
+                    self.postproc_list[ii].compare(
+                        other.postproc_list[ii],
+                        name=name + ".postproc_list[" + str(ii) + "]",
+                    )
+                )
+        if (
+            other.pre_keeper_postproc_list is None
+            and self.pre_keeper_postproc_list is not None
+        ) or (
+            other.pre_keeper_postproc_list is not None
+            and self.pre_keeper_postproc_list is None
+        ):
+            diff_list.append(name + ".pre_keeper_postproc_list None mismatch")
+        elif len(other.pre_keeper_postproc_list) != len(self.pre_keeper_postproc_list):
+            diff_list.append("len(" + name + ".pre_keeper_postproc_list)")
+        else:
+            for ii in range(len(other.pre_keeper_postproc_list)):
+                diff_list.extend(
+                    self.pre_keeper_postproc_list[ii].compare(
+                        other.pre_keeper_postproc_list[ii],
+                        name=name + ".pre_keeper_postproc_list[" + str(ii) + "]",
+                    )
+                )
+        if (
+            other.post_keeper_postproc_list is None
+            and self.post_keeper_postproc_list is not None
+        ) or (
+            other.post_keeper_postproc_list is not None
+            and self.post_keeper_postproc_list is None
+        ):
+            diff_list.append(name + ".post_keeper_postproc_list None mismatch")
+        elif len(other.post_keeper_postproc_list) != len(
+            self.post_keeper_postproc_list
+        ):
+            diff_list.append("len(" + name + ".post_keeper_postproc_list)")
+        else:
+            for ii in range(len(other.post_keeper_postproc_list)):
+                diff_list.extend(
+                    self.post_keeper_postproc_list[ii].compare(
+                        other.post_keeper_postproc_list[ii],
+                        name=name + ".post_keeper_postproc_list[" + str(ii) + "]",
+                    )
+                )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/VentilationCirc.py
+++ b/pyleecan/Classes/VentilationCirc.py
@@ -179,6 +179,23 @@ class VentilationCirc(Hole):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Hole
+        diff_list.extend(super(VentilationCirc, self).compare(other, name=name))
+        if other._Alpha0 != self._Alpha0:
+            diff_list.append(name + ".Alpha0")
+        if other._D0 != self._D0:
+            diff_list.append(name + ".D0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/VentilationPolar.py
+++ b/pyleecan/Classes/VentilationPolar.py
@@ -193,6 +193,25 @@ class VentilationPolar(Hole):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Hole
+        diff_list.extend(super(VentilationPolar, self).compare(other, name=name))
+        if other._Alpha0 != self._Alpha0:
+            diff_list.append(name + ".Alpha0")
+        if other._D0 != self._D0:
+            diff_list.append(name + ".D0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/VentilationTrap.py
+++ b/pyleecan/Classes/VentilationTrap.py
@@ -200,6 +200,27 @@ class VentilationTrap(Hole):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Hole
+        diff_list.extend(super(VentilationTrap, self).compare(other, name=name))
+        if other._Alpha0 != self._Alpha0:
+            diff_list.append(name + ".Alpha0")
+        if other._D0 != self._D0:
+            diff_list.append(name + ".D0")
+        if other._H0 != self._H0:
+            diff_list.append(name + ".H0")
+        if other._W1 != self._W1:
+            diff_list.append(name + ".W1")
+        if other._W2 != self._W2:
+            diff_list.append(name + ".W2")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/Winding.py
+++ b/pyleecan/Classes/Winding.py
@@ -224,6 +224,38 @@ class Winding(FrozenClass):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+        if other._is_reverse_wind != self._is_reverse_wind:
+            diff_list.append(name + ".is_reverse_wind")
+        if other._Nslot_shift_wind != self._Nslot_shift_wind:
+            diff_list.append(name + ".Nslot_shift_wind")
+        if other._qs != self._qs:
+            diff_list.append(name + ".qs")
+        if other._Ntcoil != self._Ntcoil:
+            diff_list.append(name + ".Ntcoil")
+        if other._Npcpp != self._Npcpp:
+            diff_list.append(name + ".Npcpp")
+        if other._type_connection != self._type_connection:
+            diff_list.append(name + ".type_connection")
+        if other._p != self._p:
+            diff_list.append(name + ".p")
+        if other._Lewout != self._Lewout:
+            diff_list.append(name + ".Lewout")
+        if (other.conductor is None and self.conductor is not None) or (
+            other.conductor is not None and self.conductor is None
+        ):
+            diff_list.append(name + ".conductor None mismatch")
+        elif self.conductor is not None:
+            diff_list.extend(
+                self.conductor.compare(other.conductor, name=name + ".conductor")
+            )
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/WindingCW1L.py
+++ b/pyleecan/Classes/WindingCW1L.py
@@ -150,6 +150,17 @@ class WindingCW1L(Winding):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Winding
+        diff_list.extend(super(WindingCW1L, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/WindingCW2LR.py
+++ b/pyleecan/Classes/WindingCW2LR.py
@@ -150,6 +150,17 @@ class WindingCW2LR(Winding):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Winding
+        diff_list.extend(super(WindingCW2LR, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/WindingCW2LT.py
+++ b/pyleecan/Classes/WindingCW2LT.py
@@ -150,6 +150,17 @@ class WindingCW2LT(Winding):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Winding
+        diff_list.extend(super(WindingCW2LT, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/WindingDW1L.py
+++ b/pyleecan/Classes/WindingDW1L.py
@@ -157,6 +157,19 @@ class WindingDW1L(Winding):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Winding
+        diff_list.extend(super(WindingDW1L, self).compare(other, name=name))
+        if other._coil_pitch != self._coil_pitch:
+            diff_list.append(name + ".coil_pitch")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/WindingDW2L.py
+++ b/pyleecan/Classes/WindingDW2L.py
@@ -136,6 +136,17 @@ class WindingDW2L(WindingDW1L):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from WindingDW1L
+        diff_list.extend(super(WindingDW2L, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/WindingSC.py
+++ b/pyleecan/Classes/WindingSC.py
@@ -150,6 +150,17 @@ class WindingSC(Winding):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Winding
+        diff_list.extend(super(WindingSC, self).compare(other, name=name))
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/WindingUD.py
+++ b/pyleecan/Classes/WindingUD.py
@@ -164,6 +164,19 @@ class WindingUD(Winding):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Winding
+        diff_list.extend(super(WindingUD, self).compare(other, name=name))
+        if not array_equal(other.user_wind_mat, self.user_wind_mat):
+            diff_list.append(name + ".user_wind_mat")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Classes/XOutput.py
+++ b/pyleecan/Classes/XOutput.py
@@ -517,6 +517,60 @@ class XOutput(Output):
             return False
         return True
 
+    def compare(self, other, name="self"):
+        """Compare two objects and return list of differences"""
+
+        if type(other) != type(self):
+            return ["type(" + name + ")"]
+        diff_list = list()
+
+        # Check the properties inherited from Output
+        diff_list.extend(super(XOutput, self).compare(other, name=name))
+        if (
+            other.paramexplorer_list is None and self.paramexplorer_list is not None
+        ) or (other.paramexplorer_list is not None and self.paramexplorer_list is None):
+            diff_list.append(name + ".paramexplorer_list None mismatch")
+        elif len(other.paramexplorer_list) != len(self.paramexplorer_list):
+            diff_list.append("len(" + name + ".paramexplorer_list)")
+        else:
+            for ii in range(len(other.paramexplorer_list)):
+                diff_list.extend(
+                    self.paramexplorer_list[ii].compare(
+                        other.paramexplorer_list[ii],
+                        name=name + ".paramexplorer_list[" + str(ii) + "]",
+                    )
+                )
+        if (other.output_list is None and self.output_list is not None) or (
+            other.output_list is not None and self.output_list is None
+        ):
+            diff_list.append(name + ".output_list None mismatch")
+        elif len(other.output_list) != len(self.output_list):
+            diff_list.append("len(" + name + ".output_list)")
+        else:
+            for ii in range(len(other.output_list)):
+                diff_list.extend(
+                    self.output_list[ii].compare(
+                        other.output_list[ii],
+                        name=name + ".output_list[" + str(ii) + "]",
+                    )
+                )
+        if (other.xoutput_dict is None and self.xoutput_dict is not None) or (
+            other.xoutput_dict is not None and self.xoutput_dict is None
+        ):
+            diff_list.append(name + ".xoutput_dict None mismatch")
+        elif len(other.xoutput_dict) != len(self.xoutput_dict):
+            diff_list.append("len(" + name + "xoutput_dict)")
+        else:
+            for key in self.xoutput_dict:
+                diff_list.extend(
+                    self.xoutput_dict[key].compare(
+                        other.xoutput_dict[key], name=name + ".xoutput_dict"
+                    )
+                )
+        if other._nb_simu != self._nb_simu:
+            diff_list.append(name + ".nb_simu")
+        return diff_list
+
     def __sizeof__(self):
         """Return the size in memory of the object (including all subobject)"""
 

--- a/pyleecan/Generator/ClassGenerator/class_generator.py
+++ b/pyleecan/Generator/ClassGenerator/class_generator.py
@@ -15,6 +15,7 @@ from ...Generator.ClassGenerator.as_dict_method_generator import generate_as_dic
 from ...Generator.ClassGenerator.properties_generator import generate_properties
 from ...Generator.ClassGenerator.init_void_method_generator import generate_init_void
 from ...Generator.ClassGenerator.eq_method_generator import generate_eq
+from ...Generator.ClassGenerator.compare_method_generator import generate_compare
 from ...Generator.ClassGenerator.size_of_method_generator import generate_size_of
 from ...Generator.ClassGenerator.set_None_method_generator import generate_set_None
 
@@ -279,6 +280,10 @@ def generate_class(gen_dict, class_name, path_to_gen):
     # Add the __eq__ method
     if "__eq__" not in class_dict["methods"]:
         class_file.write(generate_eq(gen_dict, class_dict) + "\n")
+
+    # Add the compare method
+    if "compare" not in class_dict["methods"]:
+        class_file.write(generate_compare(gen_dict, class_dict) + "\n")
 
     # Add the __sizeof__ method
     class_file.write(generate_size_of(gen_dict, class_dict))

--- a/pyleecan/Generator/ClassGenerator/compare_method_generator.py
+++ b/pyleecan/Generator/ClassGenerator/compare_method_generator.py
@@ -1,0 +1,261 @@
+from ...Generator import TAB, TAB2, TAB3, TAB4, TAB5
+from ...Generator.read_fct import is_list_pyleecan_type, is_dict_pyleecan_type
+
+
+def generate_compare(gen_dict, class_dict):
+    """Generate the code for the compare method of the class
+
+    Parameters
+    ----------
+    gen_dict : dict
+        Dict with key = class name and value = class dict (name, package, properties, methods...)
+
+    class_dict : dict
+        Dictionnary of the class to generate (keys are name, package, properties, methods...)
+
+    Returns
+    -------
+    compare_str : str
+        String containing the code for the compare method of the class
+    """
+
+    class_name = class_dict["name"]
+    compare_str = ""  # This string is for the generated code
+
+    # Code generation
+    compare_str += TAB + "def compare(self, other, name='self'):\n"
+    compare_str += TAB2 + '"""Compare two objects and return list of differences"""\n\n'
+    # Check the type
+    compare_str += TAB2 + "if type(other) != type(self):\n"
+    compare_str += TAB3 + "return ['type('+name+')']\n"
+    compare_str += TAB2 + "diff_list = list()\n"
+    # Call mother eq
+    if class_dict["mother"] != "":
+        compare_str += (
+            "\n"
+            + TAB2
+            + "# Check the properties inherited from "
+            + class_dict["mother"]
+            + "\n"
+        )
+        compare_str += (
+            TAB2
+            + "diff_list.extend(super("
+            + class_name
+            + ", self).compare(other,name=name))\n"
+        )
+    # Check that all the propoperties (except parent) are equal
+    for prop in class_dict["properties"]:
+        if prop["type"] == "ndarray":
+            compare_str += (
+                TAB2
+                + "if not array_equal(other."
+                + prop["name"]
+                + ", self."
+                + prop["name"]
+                + "):\n"
+            )
+            compare_str += TAB3 + "diff_list.append(name+'." + prop["name"] + "')\n"
+        elif prop["type"] == "[ndarray]":
+            compare_str += (
+                TAB2
+                + "if (other."
+                + prop["name"]
+                + " is None and self."
+                + prop["name"]
+                + " is not None) or (other."
+                + prop["name"]
+                + " is not None and self."
+                + prop["name"]
+                + " is None):\n"
+            )
+            compare_str += TAB3 + "diff_list.append(name+'" + prop["name"] + "')\n"
+            compare_str += (
+                TAB2
+                + "elif len(other."
+                + prop["name"]
+                + ") != len(self."
+                + prop["name"]
+                + "):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append('len('+name+'" + prop["name"] + ")')\n"
+            )
+            compare_str += TAB2 + "else:\n"
+            compare_str += TAB3 + "for ii in range(len(other." + prop["name"] + ")):\n"
+            compare_str += (
+                TAB4
+                + "if not array_equal(other."
+                + prop["name"]
+                + "[ii], self."
+                + prop["name"]
+                + "[ii]):\n"
+            )
+            compare_str += (
+                TAB5 + "diff_list.append(name+'." + prop["name"] + "'['+str(ii)+']')\n"
+            )
+        elif prop["type"] == "{ndarray}":
+            compare_str += (
+                TAB2
+                + "if (other."
+                + prop["name"]
+                + " is None and self."
+                + prop["name"]
+                + " is not None) or (other."
+                + prop["name"]
+                + " is not None and self."
+                + prop["name"]
+                + " is None):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append(name+'." + prop["name"] + " None mismatch')\n"
+            )
+            compare_str += (
+                TAB2
+                + "elif len(other."
+                + prop["name"]
+                + ") != len(self."
+                + prop["name"]
+                + "):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append('len('+name+'." + prop["name"] + ")')\n"
+            )
+            compare_str += TAB2 + "else:\n"
+            compare_str += TAB3 + "for key in other." + prop["name"] + ":\n"
+            compare_str += (
+                TAB4
+                + "if key not in self."
+                + prop["name"]
+                + " or not array_equal(other."
+                + prop["name"]
+                + "[key], self."
+                + prop["name"]
+                + "[key]):\n"
+            )
+            compare_str += (
+                TAB5 + "diff_list.append(name+'." + prop["name"] + "['+str(key)+']')\n"
+            )
+        elif prop["type"] == "function":
+            compare_str += (
+                TAB2
+                + "if other._"
+                + prop["name"]
+                + "_str != self._"
+                + prop["name"]
+                + "_str:\n"
+            )
+            compare_str += TAB3 + "diff_list.append(name+'." + prop["name"] + "')\n"
+        elif prop["type"] in ["str", "int", "float", "bool", "complex", "dict", "list"]:
+            compare_str += (
+                TAB2 + "if other._" + prop["name"] + " != self._" + prop["name"] + ":\n"
+            )
+            compare_str += TAB3 + "diff_list.append(name+'." + prop["name"] + "')\n"
+        elif is_list_pyleecan_type(prop["type"]):
+            compare_str += (
+                TAB2
+                + "if (other."
+                + prop["name"]
+                + " is None and self."
+                + prop["name"]
+                + " is not None) or (other."
+                + prop["name"]
+                + " is not None and self."
+                + prop["name"]
+                + " is None):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append(name+'." + prop["name"] + " None mismatch')\n"
+            )
+            compare_str += (
+                TAB2
+                + "elif len(other."
+                + prop["name"]
+                + ") != len(self."
+                + prop["name"]
+                + "):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append('len('+name+'." + prop["name"] + ")')\n"
+            )
+            compare_str += TAB2 + "else:\n"
+            compare_str += TAB3 + "for ii in range(len(other." + prop["name"] + ")):\n"
+            compare_str += (
+                TAB4
+                + "diff_list.extend(self."
+                + prop["name"]
+                + "[ii].compare(other."
+                + prop["name"]
+                + "[ii],name=name+'."
+                + prop["name"]
+                + "['+str(ii)+']'))\n"
+            )
+        elif is_dict_pyleecan_type(prop["type"]):
+            compare_str += (
+                TAB2
+                + "if (other."
+                + prop["name"]
+                + " is None and self."
+                + prop["name"]
+                + " is not None) or (other."
+                + prop["name"]
+                + " is not None and self."
+                + prop["name"]
+                + " is None):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append(name+'." + prop["name"] + " None mismatch')\n"
+            )
+            compare_str += (
+                TAB2
+                + "elif len(other."
+                + prop["name"]
+                + ") != len(self."
+                + prop["name"]
+                + "):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append('len('+name+'" + prop["name"] + ")')\n"
+            )
+            compare_str += TAB2 + "else:\n"
+            compare_str += TAB3 + "for key in self." + prop["name"] + ":\n"
+            compare_str += (
+                TAB4
+                + "diff_list.extend(self."
+                + prop["name"]
+                + "[key].compare(other."
+                + prop["name"]
+                + "[key],name=name+'."
+                + prop["name"]
+                + "'))\n"
+            )
+        else:  # pyleecan type
+            compare_str += (
+                TAB2
+                + "if (other."
+                + prop["name"]
+                + " is None and self."
+                + prop["name"]
+                + " is not None) or (other."
+                + prop["name"]
+                + " is not None and self."
+                + prop["name"]
+                + " is None):\n"
+            )
+            compare_str += (
+                TAB3 + "diff_list.append(name+'." + prop["name"] + " None mismatch')\n"
+            )
+            compare_str += TAB2 + "elif self." + prop["name"] + " is not None:\n"
+            compare_str += (
+                TAB3
+                + "diff_list.extend(self."
+                + prop["name"]
+                + ".compare(other."
+                + prop["name"]
+                + ",name=name+'."
+                + prop["name"]
+                + "'))\n"
+            )
+    compare_str += TAB2 + "return diff_list\n"
+
+    return compare_str

--- a/pyleecan/Generator/ClassGenerator/eq_method_generator.py
+++ b/pyleecan/Generator/ClassGenerator/eq_method_generator.py
@@ -72,7 +72,7 @@ def generate_eq(gen_dict, class_dict):
                 + prop["name"]
                 + " is None:\n"
             )
-            eq_str += TAB3 + "return True\n"
+            eq_str += TAB3 + "pass\n"
             eq_str += (
                 TAB2
                 + "elif len(other."
@@ -115,7 +115,7 @@ def generate_eq(gen_dict, class_dict):
                 + prop["name"]
                 + " is None:\n"
             )
-            eq_str += TAB3 + "return True\n"
+            eq_str += TAB3 + "pass\n"
             eq_str += (
                 TAB2
                 + "elif len(other."


### PR DESCRIPTION
Hello all,

This PR introduces a new generic method "compare" for all pyleecan objects. The idea is that __eq__ only returns a boolean but it is hard to know what is the cause of the difference. This new method returns a list with all the differences between the two objects:
![image](https://user-images.githubusercontent.com/20533034/107757317-aedf0100-6d25-11eb-90bd-c9526fcf983d.png)

I also corrected a bug in the __eq__ method (8914a36abf01065a06003b4d2da14e81ae98faaf)
Best regards,
Pierre