### PR TITLE
[CO] Improve DXF import robustness

### DIFF
--- a/pyleecan/Classes/BoreUD.py
+++ b/pyleecan/Classes/BoreUD.py
@@ -115,6 +115,8 @@ class BoreUD(Bore):
             other.line_list is not None and self.line_list is None
         ):
             diff_list.append(name + ".line_list None mismatch")
+        elif self.line_list is None:
+            pass
         elif len(other.line_list) != len(self.line_list):
             diff_list.append("len(" + name + ".line_list)")
         else:

--- a/pyleecan/Classes/Class_Dict.json
+++ b/pyleecan/Classes/Class_Dict.json
@@ -783,7 +783,9 @@
         ],
         "desc": "Class for defining data to keep on a multi-simulation",
         "is_internal": false,
-        "methods": [],
+        "methods": [
+            "as_dict"
+        ],
         "mother": "",
         "name": "DataKeeper",
         "package": "Simulation",

--- a/pyleecan/Classes/DataKeeper.py
+++ b/pyleecan/Classes/DataKeeper.py
@@ -15,6 +15,14 @@ from ..Functions.load import load_init_dict
 from ..Functions.Load.import_class import import_class
 from ._frozen import FrozenClass
 
+# Import all class method
+# Try/catch to remove unnecessary dependencies in unused method
+try:
+    from ..Methods.Simulation.DataKeeper.as_dict import as_dict
+except ImportError as error:
+    as_dict = error
+
+
 from ntpath import basename
 from os.path import isfile
 from ._check import CheckTypeError
@@ -28,6 +36,15 @@ class DataKeeper(FrozenClass):
 
     VERSION = 1
 
+    # cf Methods.Simulation.DataKeeper.as_dict
+    if isinstance(as_dict, ImportError):
+        as_dict = property(
+            fget=lambda x: raise_(
+                ImportError("Can't use DataKeeper method as_dict: " + str(as_dict))
+            )
+        )
+    else:
+        as_dict = as_dict
     # save and copy methods are available in all object
     save = save
     copy = copy
@@ -167,28 +184,6 @@ class DataKeeper(FrozenClass):
             for value in self.result:
                 S += getsizeof(value)
         return S
-
-    def as_dict(self):
-        """Convert this object in a json seriable dict (can be use in __init__)"""
-
-        DataKeeper_dict = dict()
-        DataKeeper_dict["name"] = self.name
-        DataKeeper_dict["symbol"] = self.symbol
-        DataKeeper_dict["unit"] = self.unit
-        if self._keeper_str is not None:
-            DataKeeper_dict["keeper"] = self._keeper_str
-        else:
-            DataKeeper_dict["keeper"] = None
-        if self._error_keeper_str is not None:
-            DataKeeper_dict["error_keeper"] = self._error_keeper_str
-        else:
-            DataKeeper_dict["error_keeper"] = None
-        DataKeeper_dict["result"] = (
-            self.result.copy() if self.result is not None else None
-        )
-        # The class name is added to the dict for deserialisation purpose
-        DataKeeper_dict["__class__"] = "DataKeeper"
-        return DataKeeper_dict
 
     def _set_None(self):
         """Set all the properties to None (except pyleecan object)"""

--- a/pyleecan/Classes/HoleUD.py
+++ b/pyleecan/Classes/HoleUD.py
@@ -205,6 +205,8 @@ class HoleUD(HoleMag):
             other.surf_list is not None and self.surf_list is None
         ):
             diff_list.append(name + ".surf_list None mismatch")
+        elif self.surf_list is None:
+            pass
         elif len(other.surf_list) != len(self.surf_list):
             diff_list.append("len(" + name + ".surf_list)")
         else:
@@ -218,6 +220,8 @@ class HoleUD(HoleMag):
             other.magnet_dict is not None and self.magnet_dict is None
         ):
             diff_list.append(name + ".magnet_dict None mismatch")
+        elif self.magnet_dict is None:
+            pass
         elif len(other.magnet_dict) != len(self.magnet_dict):
             diff_list.append("len(" + name + "magnet_dict)")
         else:

--- a/pyleecan/Classes/ImportData.py
+++ b/pyleecan/Classes/ImportData.py
@@ -157,6 +157,8 @@ class ImportData(FrozenClass):
             other.axes is not None and self.axes is None
         ):
             diff_list.append(name + ".axes None mismatch")
+        elif self.axes is None:
+            pass
         elif len(other.axes) != len(self.axes):
             diff_list.append("len(" + name + ".axes)")
         else:

--- a/pyleecan/Classes/ImportGenMatrixSin.py
+++ b/pyleecan/Classes/ImportGenMatrixSin.py
@@ -135,6 +135,8 @@ class ImportGenMatrixSin(ImportMatrix):
             other.sin_list is not None and self.sin_list is None
         ):
             diff_list.append(name + ".sin_list None mismatch")
+        elif self.sin_list is None:
+            pass
         elif len(other.sin_list) != len(self.sin_list):
             diff_list.append("len(" + name + ".sin_list)")
         else:

--- a/pyleecan/Classes/ImportVectorField.py
+++ b/pyleecan/Classes/ImportVectorField.py
@@ -129,6 +129,8 @@ class ImportVectorField(FrozenClass):
             other.components is not None and self.components is None
         ):
             diff_list.append(name + ".components None mismatch")
+        elif self.components is None:
+            pass
         elif len(other.components) != len(self.components):
             diff_list.append("len(" + name + "components)")
         else:

--- a/pyleecan/Classes/LamHole.py
+++ b/pyleecan/Classes/LamHole.py
@@ -337,6 +337,8 @@ class LamHole(Lamination):
             other.hole is not None and self.hole is None
         ):
             diff_list.append(name + ".hole None mismatch")
+        elif self.hole is None:
+            pass
         elif len(other.hole) != len(self.hole):
             diff_list.append("len(" + name + ".hole)")
         else:

--- a/pyleecan/Classes/LamSlotMulti.py
+++ b/pyleecan/Classes/LamSlotMulti.py
@@ -309,6 +309,8 @@ class LamSlotMulti(Lamination):
             other.slot_list is not None and self.slot_list is None
         ):
             diff_list.append(name + ".slot_list None mismatch")
+        elif self.slot_list is None:
+            pass
         elif len(other.slot_list) != len(self.slot_list):
             diff_list.append("len(" + name + ".slot_list)")
         else:

--- a/pyleecan/Classes/Lamination.py
+++ b/pyleecan/Classes/Lamination.py
@@ -524,6 +524,8 @@ class Lamination(FrozenClass):
             other.axial_vent is not None and self.axial_vent is None
         ):
             diff_list.append(name + ".axial_vent None mismatch")
+        elif self.axial_vent is None:
+            pass
         elif len(other.axial_vent) != len(self.axial_vent):
             diff_list.append("len(" + name + ".axial_vent)")
         else:
@@ -537,6 +539,8 @@ class Lamination(FrozenClass):
             other.notch is not None and self.notch is None
         ):
             diff_list.append(name + ".notch None mismatch")
+        elif self.notch is None:
+            pass
         elif len(other.notch) != len(self.notch):
             diff_list.append("len(" + name + ".notch)")
         else:

--- a/pyleecan/Classes/Loss.py
+++ b/pyleecan/Classes/Loss.py
@@ -156,6 +156,8 @@ class Loss(FrozenClass):
             other.model_list is not None and self.model_list is None
         ):
             diff_list.append(name + ".model_list None mismatch")
+        elif self.model_list is None:
+            pass
         elif len(other.model_list) != len(self.model_list):
             diff_list.append("len(" + name + ".model_list)")
         else:

--- a/pyleecan/Classes/MachineUD.py
+++ b/pyleecan/Classes/MachineUD.py
@@ -169,6 +169,8 @@ class MachineUD(Machine):
             other.lam_list is not None and self.lam_list is None
         ):
             diff_list.append(name + ".lam_list None mismatch")
+        elif self.lam_list is None:
+            pass
         elif len(other.lam_list) != len(self.lam_list):
             diff_list.append("len(" + name + ".lam_list)")
         else:

--- a/pyleecan/Classes/MeshMat.py
+++ b/pyleecan/Classes/MeshMat.py
@@ -259,6 +259,8 @@ class MeshMat(Mesh):
             other.cell is not None and self.cell is None
         ):
             diff_list.append(name + ".cell None mismatch")
+        elif self.cell is None:
+            pass
         elif len(other.cell) != len(self.cell):
             diff_list.append("len(" + name + "cell)")
         else:

--- a/pyleecan/Classes/MeshSolution.py
+++ b/pyleecan/Classes/MeshSolution.py
@@ -306,6 +306,8 @@ class MeshSolution(FrozenClass):
             other.mesh is not None and self.mesh is None
         ):
             diff_list.append(name + ".mesh None mismatch")
+        elif self.mesh is None:
+            pass
         elif len(other.mesh) != len(self.mesh):
             diff_list.append("len(" + name + ".mesh)")
         else:
@@ -321,6 +323,8 @@ class MeshSolution(FrozenClass):
             other.solution is not None and self.solution is None
         ):
             diff_list.append(name + ".solution None mismatch")
+        elif self.solution is None:
+            pass
         elif len(other.solution) != len(self.solution):
             diff_list.append("len(" + name + ".solution)")
         else:
@@ -334,6 +338,8 @@ class MeshSolution(FrozenClass):
             other.group is not None and self.group is None
         ):
             diff_list.append(name + ".group None mismatch")
+        elif self.group is None:
+            pass
         elif len(other.group) != len(self.group):
             diff_list.append("len(" + name + ".group)")
         else:

--- a/pyleecan/Classes/OptiProblem.py
+++ b/pyleecan/Classes/OptiProblem.py
@@ -190,6 +190,8 @@ class OptiProblem(FrozenClass):
             other.design_var is not None and self.design_var is None
         ):
             diff_list.append(name + ".design_var None mismatch")
+        elif self.design_var is None:
+            pass
         elif len(other.design_var) != len(self.design_var):
             diff_list.append("len(" + name + ".design_var)")
         else:
@@ -203,6 +205,8 @@ class OptiProblem(FrozenClass):
             other.obj_func is not None and self.obj_func is None
         ):
             diff_list.append(name + ".obj_func None mismatch")
+        elif self.obj_func is None:
+            pass
         elif len(other.obj_func) != len(self.obj_func):
             diff_list.append("len(" + name + ".obj_func)")
         else:
@@ -218,6 +222,8 @@ class OptiProblem(FrozenClass):
             other.constraint is not None and self.constraint is None
         ):
             diff_list.append(name + ".constraint None mismatch")
+        elif self.constraint is None:
+            pass
         elif len(other.constraint) != len(self.constraint):
             diff_list.append("len(" + name + ".constraint)")
         else:
@@ -233,6 +239,8 @@ class OptiProblem(FrozenClass):
             other.datakeeper_list is not None and self.datakeeper_list is None
         ):
             diff_list.append(name + ".datakeeper_list None mismatch")
+        elif self.datakeeper_list is None:
+            pass
         elif len(other.datakeeper_list) != len(self.datakeeper_list):
             diff_list.append("len(" + name + ".datakeeper_list)")
         else:

--- a/pyleecan/Classes/OutLoss.py
+++ b/pyleecan/Classes/OutLoss.py
@@ -152,6 +152,8 @@ class OutLoss(FrozenClass):
             other.loss_list is not None and self.loss_list is None
         ):
             diff_list.append(name + ".loss_list None mismatch")
+        elif self.loss_list is None:
+            pass
         elif len(other.loss_list) != len(self.loss_list):
             diff_list.append("len(" + name + ".loss_list)")
         else:
@@ -165,6 +167,8 @@ class OutLoss(FrozenClass):
             other.meshsol_list is not None and self.meshsol_list is None
         ):
             diff_list.append(name + ".meshsol_list None mismatch")
+        elif self.meshsol_list is None:
+            pass
         elif len(other.meshsol_list) != len(self.meshsol_list):
             diff_list.append("len(" + name + ".meshsol_list)")
         else:

--- a/pyleecan/Classes/OutMag.py
+++ b/pyleecan/Classes/OutMag.py
@@ -296,6 +296,8 @@ class OutMag(FrozenClass):
             other.Phi_wind is not None and self.Phi_wind is None
         ):
             diff_list.append(name + ".Phi_wind None mismatch")
+        elif self.Phi_wind is None:
+            pass
         elif len(other.Phi_wind) != len(self.Phi_wind):
             diff_list.append("len(" + name + "Phi_wind)")
         else:

--- a/pyleecan/Classes/OutMagFEMM.py
+++ b/pyleecan/Classes/OutMagFEMM.py
@@ -124,6 +124,8 @@ class OutMagFEMM(OutInternal):
             other.handler_list is not None and self.handler_list is None
         ):
             diff_list.append(name + ".handler_list None mismatch")
+        elif self.handler_list is None:
+            pass
         elif len(other.handler_list) != len(self.handler_list):
             diff_list.append("len(" + name + ".handler_list)")
         else:

--- a/pyleecan/Classes/Simulation.py
+++ b/pyleecan/Classes/Simulation.py
@@ -232,6 +232,8 @@ class Simulation(FrozenClass):
             other.postproc_list is not None and self.postproc_list is None
         ):
             diff_list.append(name + ".postproc_list None mismatch")
+        elif self.postproc_list is None:
+            pass
         elif len(other.postproc_list) != len(self.postproc_list):
             diff_list.append("len(" + name + ".postproc_list)")
         else:

--- a/pyleecan/Classes/SlotUD.py
+++ b/pyleecan/Classes/SlotUD.py
@@ -193,6 +193,8 @@ class SlotUD(Slot):
             other.line_list is not None and self.line_list is None
         ):
             diff_list.append(name + ".line_list None mismatch")
+        elif self.line_list is None:
+            pass
         elif len(other.line_list) != len(self.line_list):
             diff_list.append("len(" + name + ".line_list)")
         else:

--- a/pyleecan/Classes/SlotUD2.py
+++ b/pyleecan/Classes/SlotUD2.py
@@ -164,6 +164,8 @@ class SlotUD2(Slot):
             other.line_list is not None and self.line_list is None
         ):
             diff_list.append(name + ".line_list None mismatch")
+        elif self.line_list is None:
+            pass
         elif len(other.line_list) != len(self.line_list):
             diff_list.append("len(" + name + ".line_list)")
         else:

--- a/pyleecan/Classes/SurfLine.py
+++ b/pyleecan/Classes/SurfLine.py
@@ -254,6 +254,8 @@ class SurfLine(Surface):
             other.line_list is not None and self.line_list is None
         ):
             diff_list.append(name + ".line_list None mismatch")
+        elif self.line_list is None:
+            pass
         elif len(other.line_list) != len(self.line_list):
             diff_list.append("len(" + name + ".line_list)")
         else:

--- a/pyleecan/Classes/VarParam.py
+++ b/pyleecan/Classes/VarParam.py
@@ -203,6 +203,8 @@ class VarParam(VarSimu):
             other.paramexplorer_list is None and self.paramexplorer_list is not None
         ) or (other.paramexplorer_list is not None and self.paramexplorer_list is None):
             diff_list.append(name + ".paramexplorer_list None mismatch")
+        elif self.paramexplorer_list is None:
+            pass
         elif len(other.paramexplorer_list) != len(self.paramexplorer_list):
             diff_list.append("len(" + name + ".paramexplorer_list)")
         else:

--- a/pyleecan/Classes/VarSimu.py
+++ b/pyleecan/Classes/VarSimu.py
@@ -267,6 +267,8 @@ class VarSimu(FrozenClass):
             other.datakeeper_list is not None and self.datakeeper_list is None
         ):
             diff_list.append(name + ".datakeeper_list None mismatch")
+        elif self.datakeeper_list is None:
+            pass
         elif len(other.datakeeper_list) != len(self.datakeeper_list):
             diff_list.append("len(" + name + ".datakeeper_list)")
         else:
@@ -291,6 +293,8 @@ class VarSimu(FrozenClass):
             other.postproc_list is not None and self.postproc_list is None
         ):
             diff_list.append(name + ".postproc_list None mismatch")
+        elif self.postproc_list is None:
+            pass
         elif len(other.postproc_list) != len(self.postproc_list):
             diff_list.append("len(" + name + ".postproc_list)")
         else:
@@ -309,6 +313,8 @@ class VarSimu(FrozenClass):
             and self.pre_keeper_postproc_list is None
         ):
             diff_list.append(name + ".pre_keeper_postproc_list None mismatch")
+        elif self.pre_keeper_postproc_list is None:
+            pass
         elif len(other.pre_keeper_postproc_list) != len(self.pre_keeper_postproc_list):
             diff_list.append("len(" + name + ".pre_keeper_postproc_list)")
         else:
@@ -327,6 +333,8 @@ class VarSimu(FrozenClass):
             and self.post_keeper_postproc_list is None
         ):
             diff_list.append(name + ".post_keeper_postproc_list None mismatch")
+        elif self.post_keeper_postproc_list is None:
+            pass
         elif len(other.post_keeper_postproc_list) != len(
             self.post_keeper_postproc_list
         ):

--- a/pyleecan/Classes/XOutput.py
+++ b/pyleecan/Classes/XOutput.py
@@ -530,6 +530,8 @@ class XOutput(Output):
             other.paramexplorer_list is None and self.paramexplorer_list is not None
         ) or (other.paramexplorer_list is not None and self.paramexplorer_list is None):
             diff_list.append(name + ".paramexplorer_list None mismatch")
+        elif self.paramexplorer_list is None:
+            pass
         elif len(other.paramexplorer_list) != len(self.paramexplorer_list):
             diff_list.append("len(" + name + ".paramexplorer_list)")
         else:
@@ -544,6 +546,8 @@ class XOutput(Output):
             other.output_list is not None and self.output_list is None
         ):
             diff_list.append(name + ".output_list None mismatch")
+        elif self.output_list is None:
+            pass
         elif len(other.output_list) != len(self.output_list):
             diff_list.append("len(" + name + ".output_list)")
         else:
@@ -558,6 +562,8 @@ class XOutput(Output):
             other.xoutput_dict is not None and self.xoutput_dict is None
         ):
             diff_list.append(name + ".xoutput_dict None mismatch")
+        elif self.xoutput_dict is None:
+            pass
         elif len(other.xoutput_dict) != len(self.xoutput_dict):
             diff_list.append("len(" + name + "xoutput_dict)")
         else:

--- a/pyleecan/GUI/Dxf/DXF_Hole.py
+++ b/pyleecan/GUI/Dxf/DXF_Hole.py
@@ -1,18 +1,20 @@
+from logging import getLogger
 from os.path import dirname, isfile
 
 from ezdxf import readfile
 from numpy import angle as np_angle
 from numpy import array
-from pyleecan.GUI.Dxf.dxf_to_pyleecan_list import dxf_to_pyleecan_list
-from pyleecan.GUI.Resources import pixmap_dict
 from PySide2.QtCore import QSize, Qt
 from PySide2.QtGui import QIcon, QPixmap
-from PySide2.QtWidgets import QComboBox, QFileDialog, QPushButton, QDialog
+from PySide2.QtWidgets import QComboBox, QDialog, QFileDialog, QMessageBox, QPushButton
 
 from ...Classes.HoleUD import HoleUD
 from ...Classes.Magnet import Magnet
 from ...Classes.SurfLine import SurfLine
+from ...GUI.Dxf.dxf_to_pyleecan_list import dxf_to_pyleecan_list
+from ...GUI.Resources import pixmap_dict
 from ...GUI.Tools.MPLCanvas import MPLCanvas2
+from ...loggers import GUI_LOG_NAME
 from .Ui_DXF_Hole import Ui_DXF_Hole
 
 # Column index for table
@@ -103,14 +105,22 @@ class DXF_Hole(Ui_DXF_Hole, QDialog):
             a DXF_Hole object
         """
 
+        getLogger(GUI_LOG_NAME).debug("Reading dxf file: " + self.dxf_path)
         # Read the DXF file
-        document = readfile(self.dxf_path)
-        modelspace = document.modelspace()
-        # Convert DXF to pyleecan objects
-        self.line_list = dxf_to_pyleecan_list(modelspace)
-        # Display
-        self.selected_list = [False for line in self.line_list]
-        self.update_graph()
+        try:
+            document = readfile(self.dxf_path)
+            modelspace = document.modelspace()
+            # Convert DXF to pyleecan objects
+            self.line_list = dxf_to_pyleecan_list(modelspace)
+            # Display
+            self.selected_list = [False for line in self.line_list]
+            self.update_graph()
+        except Exception as e:
+            QMessageBox().critical(
+                self,
+                self.tr("Error"),
+                self.tr("Error while reading dxf file:\n" + str(e)),
+            )
 
     def init_graph(self):
         """Initialize the viewer

--- a/pyleecan/GUI/Dxf/DXF_Slot.py
+++ b/pyleecan/GUI/Dxf/DXF_Slot.py
@@ -1,20 +1,23 @@
+from logging import getLogger
 from os.path import dirname, isfile
 
+import matplotlib.pyplot as plt
 from ezdxf import readfile
-from numpy import angle as np_angle, argmin
-from numpy import array
-from pyleecan.GUI.Dxf.dxf_to_pyleecan_list import dxf_to_pyleecan_list
-from pyleecan.GUI.Resources import pixmap_dict
+from numpy import angle as np_angle
+from numpy import argmin, array
 from PySide2.QtCore import QSize, Qt
 from PySide2.QtGui import QIcon, QPixmap
-from PySide2.QtWidgets import QComboBox, QFileDialog, QPushButton, QDialog
-import matplotlib.pyplot as plt
-from ...Classes.SlotUD import SlotUD
-from ...Classes.Magnet import Magnet
+from PySide2.QtWidgets import QComboBox, QDialog, QFileDialog, QMessageBox, QPushButton
+
 from ...Classes.LamSlot import LamSlot
-from ...GUI.Tools.MPLCanvas import MPLCanvas2
-from .Ui_DXF_Slot import Ui_DXF_Slot
+from ...Classes.Magnet import Magnet
+from ...Classes.SlotUD import SlotUD
 from ...definitions import config_dict
+from ...GUI.Dxf.dxf_to_pyleecan_list import dxf_to_pyleecan_list
+from ...GUI.Resources import pixmap_dict
+from ...GUI.Tools.MPLCanvas import MPLCanvas2
+from ...loggers import GUI_LOG_NAME
+from .Ui_DXF_Slot import Ui_DXF_Slot
 
 # Column index for table
 TYPE_COL = 0
@@ -91,14 +94,22 @@ class DXF_Slot(Ui_DXF_Slot, QDialog):
             a DXF_Slot object
         """
 
+        getLogger(GUI_LOG_NAME).debug("Reading dxf file: " + self.dxf_path)
         # Read the DXF file
-        document = readfile(self.dxf_path)
-        modelspace = document.modelspace()
-        # Convert DXF to pyleecan objects
-        self.line_list = dxf_to_pyleecan_list(modelspace)
-        # Display
-        self.selected_list = [False for line in self.line_list]
-        self.update_graph()
+        try:
+            document = readfile(self.dxf_path)
+            modelspace = document.modelspace()
+            # Convert DXF to pyleecan objects
+            self.line_list = dxf_to_pyleecan_list(modelspace)
+            # Display
+            self.selected_list = [False for line in self.line_list]
+            self.update_graph()
+        except Exception as e:
+            QMessageBox().critical(
+                self,
+                self.tr("Error"),
+                self.tr("Error while reading dxf file:\n" + str(e)),
+            )
 
     def init_graph(self):
         """Initialize the viewer

--- a/pyleecan/GUI/Dxf/dxf_to_pyleecan_list.py
+++ b/pyleecan/GUI/Dxf/dxf_to_pyleecan_list.py
@@ -2,6 +2,8 @@ from ...Classes.Segment import Segment
 from ...Classes.Arc1 import Arc1
 from ...Classes.Arc2 import Arc2
 from math import cos, sin, pi
+from logging import getLogger
+from ...loggers import GUI_LOG_NAME
 
 
 def dxf_to_pyleecan_list(entities):
@@ -11,15 +13,12 @@ def dxf_to_pyleecan_list(entities):
     """
     obj_list = []
     for entity in entities:
-
         dxftype = entity.dxftype()
         dxf = entity.dxf
         if dxftype == "LINE":  # {"LINE", "XLINE", "RAY"}:
             start = complex(*dxf.start[:-1])
             end = complex(*dxf.end[:-1])
             obj_list.append(Segment(start, end))
-        elif dxftype == "CIRCLE":
-            raise NotImplementedError
         elif dxftype == "ARC":
             start_angle = dxf.start_angle / 180 * pi
             end_angle = dxf.end_angle / 180 * pi
@@ -42,6 +41,6 @@ def dxf_to_pyleecan_list(entities):
                 Arc1(begin=begin, end=end, radius=dxf.radius, is_trigo_direction=True)
             )
         else:
-            raise NotImplementedError
+            getLogger(GUI_LOG_NAME).warning("Unable to load dxftype="+str(dxftype)". Removing element from preview")
 
     return obj_list

--- a/pyleecan/GUI/Dxf/dxf_to_pyleecan_list.py
+++ b/pyleecan/GUI/Dxf/dxf_to_pyleecan_list.py
@@ -41,6 +41,10 @@ def dxf_to_pyleecan_list(entities):
                 Arc1(begin=begin, end=end, radius=dxf.radius, is_trigo_direction=True)
             )
         else:
-            getLogger(GUI_LOG_NAME).warning("Unable to load dxftype="+str(dxftype)". Removing element from preview")
+            getLogger(GUI_LOG_NAME).warning(
+                "Unable to load dxftype="
+                + str(dxftype)
+                + ". Removing element from preview"
+            )
 
     return obj_list

--- a/pyleecan/Generator/ClassesRef/Simulation/DataKeeper.csv
+++ b/pyleecan/Generator/ClassesRef/Simulation/DataKeeper.csv
@@ -1,5 +1,5 @@
 Variable name,Unit,Description (EN),Size,Type,Default value,Minimum value,Maximum value,,Package,Inherit,Methods,Constant Name,Constant Value,Class description
-name,-,Data name,0,str,,,,,Simulation,,,VERSION,1,Class for defining data to keep on a multi-simulation
+name,-,Data name,0,str,,,,,Simulation,,as_dict,VERSION,1,Class for defining data to keep on a multi-simulation
 symbol,-,Data symbol,,str,,,,,,,,,,
 unit,-,Data unit,,str,,,,,,,,,,
 keeper,-,Function that takes an Output in argument and return a value,,function,None,,,,,,,,,

--- a/pyleecan/Methods/Simulation/DataKeeper/as_dict.py
+++ b/pyleecan/Methods/Simulation/DataKeeper/as_dict.py
@@ -1,0 +1,23 @@
+def as_dict(self):
+    """Convert this object in a json seriable dict (can be use in __init__)"""
+
+    DataKeeper_dict = dict()
+    DataKeeper_dict["name"] = self.name
+    DataKeeper_dict["symbol"] = self.symbol
+    DataKeeper_dict["unit"] = self.unit
+    if self._keeper_str is not None:
+        DataKeeper_dict["keeper"] = self._keeper_str
+    else:
+        DataKeeper_dict["keeper"] = None
+    if self._error_keeper_str is not None:
+        DataKeeper_dict["error_keeper"] = self._error_keeper_str
+    else:
+        DataKeeper_dict["error_keeper"] = None
+    DataKeeper_dict["result"] = self.result.copy() if self.result is not None else None
+    if DataKeeper_dict["result"] is not None:
+        for ii in range(len(DataKeeper_dict["result"])):
+            if hasattr(DataKeeper_dict["result"][ii], "as_dict"):
+                DataKeeper_dict["result"][ii] = DataKeeper_dict["result"][ii].as_dict()
+    # The class name is added to the dict for deserialisation purpose
+    DataKeeper_dict["__class__"] = "DataKeeper"
+    return DataKeeper_dict

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ install_requires = [
 ]
 
 
-
 tests_require = ["ddt>=1.3.1", "pytest>=5.4.1", "mock>=4.0.2", "nbformat", "nbconvert"]
 
 setuptools.setup(


### PR DESCRIPTION
This PR remove a crash from the GUI when the selected dxf file is incorrect. Now a dxf containing CIRCLE or SPLINE object would just ignore these objects and load all the ARC and LINE objects (instead of doing nothing). One day we need to investigate how to properly handle these objects (reference dxf files welcomed). 