### PR TITLE
[CO] avoid grid toggle + plot title only if needed

### DIFF
--- a/pyleecan/Functions/Plot/plot_2D.py
+++ b/pyleecan/Functions/Plot/plot_2D.py
@@ -212,11 +212,10 @@ def plot_2D(
     if is_logscale_y:
         ax.set_yscale("log")
 
-    if is_disp_title:
+    if is_disp_title and title not in [None, ""]:
         ax.set_title(title)
 
-    if is_grid:
-        ax.grid()
+    ax.grid(is_grid)
 
     if ndatas > 1 and not no_legend:
         ax.legend(prop={"family": FONT_NAME, "size": FONT_SIZE_LEGEND})

--- a/pyleecan/Functions/Plot/plot_3D.py
+++ b/pyleecan/Functions/Plot/plot_3D.py
@@ -209,7 +209,7 @@ def plot_3D(
     if is_logscale_y:
         ax.yscale("log")
 
-    if is_disp_title:
+    if is_disp_title and title not in [None, ""]:
         ax.set_title(title)
 
     if is_3d:

--- a/pyleecan/Functions/Plot/plot_4D.py
+++ b/pyleecan/Functions/Plot/plot_4D.py
@@ -188,7 +188,7 @@ def plot_4D(
     if is_logscale_y:
         ax.yscale("log")
 
-    if is_disp_title:
+    if is_disp_title and title not in [None, ""]:
         ax.set_title(title)
 
     if is_3d:


### PR DESCRIPTION
If one wants to plot multiple data (e.g. 2D and 3D) into one figure, this PR fixes grid toggle (on 2D) and unwanted title overriding.