### PR TITLE
[CO] Scroll widget for "right parameter column"

### DIFF
--- a/Tests/GUI/DMachineSetup/test_SMachineDimension.py
+++ b/Tests/GUI/DMachineSetup/test_SMachineDimension.py
@@ -67,7 +67,7 @@ class TestSMachineDimension(object):
         assert setup["widget"].lf_Lfra.value() == 0.25
         assert setup["widget"].g_frame.isChecked() == True
         assert setup["widget"].g_shaft.isChecked() == True
-        assert setup["widget"].out_Drsh.text() == "Drsh = 2*Rotor.Rint = 0.22 [m]"
+        assert setup["widget"].out_Drsh.text() == "Drsh = 0.22 [m]"
 
     def test_init_no_shaft(self, setup):
         """Check that the Widget spinbox initialise to the lamination value"""

--- a/pyleecan/GUI/Dialog/DMachineSetup/DMachineSetup.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/DMachineSetup.ui
@@ -6,80 +6,63 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1001</width>
-    <height>721</height>
+    <width>1076</width>
+    <height>682</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Pyleecan Machine Setup</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QHBoxLayout" name="main_layout">
    <item>
-    <widget class="QListWidget" name="nav_step">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>190</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="main_layout">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="b_save">
-         <property name="text">
-          <string>Save</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="b_load">
-         <property name="text">
-          <string>Load</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QPushButton" name="b_load">
+       <property name="text">
+        <string>Load</string>
+       </property>
+      </widget>
      </item>
      <item>
-      <widget class="QWidget" name="w_step" native="true">
+      <widget class="QListWidget" name="nav_step">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="minimumSize">
+       <property name="maximumSize">
         <size>
-         <width>800</width>
-         <height>660</height>
+         <width>190</width>
+         <height>16777215</height>
         </size>
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="b_save">
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QWidget" name="w_step" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>800</width>
+       <height>660</height>
+      </size>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM50/PHoleM50.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM50/PHoleM50.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>978</width>
+    <width>1215</width>
     <height>561</height>
    </rect>
   </property>
@@ -87,10 +87,10 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;H2 &amp;lt; H3&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;W1 &amp;lt; W0&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;H1 &amp;lt; H0 &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;H2 &amp;lt; H3&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;W1 &amp;lt; W0&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;H1 &amp;lt; H0 &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -100,285 +100,298 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="7" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H4">
-          <property name="text">
-           <string>H4</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H4"/>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_H4">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H3">
-          <property name="text">
-           <string>H3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H3"/>
-        </item>
-        <item row="9" column="2">
-         <widget class="QLabel" name="unit_W4">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="9" column="1">
-         <widget class="FloatEdit" name="lf_W4">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="in_W4">
-          <property name="text">
-           <string>W4</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_0" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_1" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_2" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>537</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="7" column="2">
+          <widget class="QLabel" name="unit_W2">
            <property name="text">
-            <string>Slot suface (2 part) : ?</string>
+            <string>m</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_magnet_surface">
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_W1">
            <property name="text">
-            <string>Single Magnet surface : ?</string>
+            <string>m</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_alpha">
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H2">
            <property name="text">
-            <string>Alpha : ?</string>
+            <string>m</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_W5">
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H4">
            <property name="text">
-            <string>W5 : ?</string>
+            <string>H4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H4"/>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H4">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H3">
+           <property name="text">
+            <string>H3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H3"/>
+         </item>
+         <item row="9" column="2">
+          <widget class="QLabel" name="unit_W4">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="9" column="1">
+          <widget class="FloatEdit" name="lf_W4">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="in_W4">
+           <property name="text">
+            <string>W4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
            </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_0" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_1" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_2" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Slot suface (2 part) : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_magnet_surface">
+            <property name="text">
+             <string>Single Magnet surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_alpha">
+            <property name="text">
+             <string>Alpha : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_W5">
+            <property name="text">
+             <string>W5 : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM50/Ui_PHoleM50.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM50/Ui_PHoleM50.py
@@ -19,7 +19,7 @@ class Ui_PHoleM50(object):
     def setupUi(self, PHoleM50):
         if not PHoleM50.objectName():
             PHoleM50.setObjectName(u"PHoleM50")
-        PHoleM50.resize(978, 561)
+        PHoleM50.resize(1215, 561)
         PHoleM50.setMinimumSize(QSize(740, 440))
         PHoleM50.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleM50)
@@ -62,191 +62,195 @@ class Ui_PHoleM50(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_3)
 
-        self.widget = QWidget(PHoleM50)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.scrollArea = QScrollArea(PHoleM50)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 537))
+        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 7, 2, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 6, 2, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 5, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 2, 2, 1, 1)
 
-        self.in_H4 = QLabel(self.widget)
+        self.in_H4 = QLabel(self.scrollAreaWidgetContents)
         self.in_H4.setObjectName(u"in_H4")
 
         self.gridLayout.addWidget(self.in_H4, 4, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 2, 1, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 1, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 1, 2, 1, 1)
 
-        self.lf_H4 = FloatEdit(self.widget)
+        self.lf_H4 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H4.setObjectName(u"lf_H4")
 
         self.gridLayout.addWidget(self.lf_H4, 4, 1, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 6, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 0, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 0, 2, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 8, 1, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 1, 0, 1, 1)
 
-        self.unit_H4 = QLabel(self.widget)
+        self.unit_H4 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H4.setObjectName(u"unit_H4")
 
         self.gridLayout.addWidget(self.unit_H4, 4, 2, 1, 1)
 
-        self.in_H3 = QLabel(self.widget)
+        self.in_H3 = QLabel(self.scrollAreaWidgetContents)
         self.in_H3.setObjectName(u"in_H3")
 
         self.gridLayout.addWidget(self.in_H3, 3, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 5, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 7, 0, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 0, 0, 1, 1)
 
-        self.unit_H3 = QLabel(self.widget)
+        self.unit_H3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H3.setObjectName(u"unit_H3")
 
         self.gridLayout.addWidget(self.unit_H3, 3, 2, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 6, 1, 1, 1)
 
-        self.lf_H3 = FloatEdit(self.widget)
+        self.lf_H3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H3.setObjectName(u"lf_H3")
 
         self.gridLayout.addWidget(self.lf_H3, 3, 1, 1, 1)
 
-        self.unit_W4 = QLabel(self.widget)
+        self.unit_W4 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W4.setObjectName(u"unit_W4")
 
         self.gridLayout.addWidget(self.unit_W4, 9, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 5, 0, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 2, 0, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 8, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 7, 1, 1, 1)
 
-        self.lf_W4 = FloatEdit(self.widget)
+        self.lf_W4 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W4.setObjectName(u"lf_W4")
 
         self.gridLayout.addWidget(self.lf_W4, 9, 1, 1, 1)
 
-        self.in_W4 = QLabel(self.widget)
+        self.in_W4 = QLabel(self.scrollAreaWidgetContents)
         self.in_W4.setObjectName(u"in_W4")
 
         self.gridLayout.addWidget(self.in_W4, 9, 0, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 8, 2, 1, 1)
 
-        self.verticalLayout_2.addLayout(self.gridLayout)
+        self.verticalLayout_4.addLayout(self.gridLayout)
 
-        self.w_mat_0 = WMatSelect(self.widget)
+        self.w_mat_0 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_0.setObjectName(u"w_mat_0")
         self.w_mat_0.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_0)
+        self.verticalLayout_4.addWidget(self.w_mat_0)
 
-        self.w_mat_1 = WMatSelect(self.widget)
+        self.w_mat_1 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_1.setObjectName(u"w_mat_1")
         self.w_mat_1.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_1)
+        self.verticalLayout_4.addWidget(self.w_mat_1)
 
-        self.w_mat_2 = WMatSelect(self.widget)
+        self.w_mat_2 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_2.setObjectName(u"w_mat_2")
         self.w_mat_2.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_2)
+        self.verticalLayout_4.addWidget(self.w_mat_2)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout_2.addItem(self.verticalSpacer)
+        self.verticalLayout_4.addItem(self.verticalSpacer)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -271,9 +275,11 @@ class Ui_PHoleM50(object):
 
         self.verticalLayout.addWidget(self.out_W5)
 
-        self.verticalLayout_2.addWidget(self.g_output)
+        self.verticalLayout_4.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_H0, self.lf_H1)
         QWidget.setTabOrder(self.lf_H1, self.lf_H2)
@@ -300,11 +306,11 @@ class Ui_PHoleM50(object):
                 '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
                 "p, li { white-space: pre-wrap; }\n"
                 "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;\">\n"
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:14pt;">H2 &lt; H3</span></p>\n'
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2'
-                "'; font-size:14pt;\">W1 &lt; W0</span></p>\n"
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:14pt;">H1 &lt; H0 </span></p></body></html>',
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">H2 &lt; H3</span></p>\n'
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">W1 &lt; W0</span></p>\n'
+                '<p align="center" style=" margin-top:0px'
+                '; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">H1 &lt; H0 </span></p></body></html>',
                 None,
             )
         )

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM51/PHoleM51.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM51/PHoleM51.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>978</width>
-    <height>440</height>
+    <width>1078</width>
+    <height>592</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -99,9 +99,9 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;W3+W2 &amp;lt; W0&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;W3+W2 &amp;lt; W0&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -111,328 +111,341 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
-        </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_W1">
-          <property name="cursorPosition">
-           <number>0</number>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>rad</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="in_W4">
-          <property name="text">
-           <string>W4</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="FloatEdit" name="lf_W4"/>
-        </item>
-        <item row="7" column="2">
-         <widget class="QLabel" name="unit_W4">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="in_W5">
-          <property name="text">
-           <string>W5</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="FloatEdit" name="lf_W5"/>
-        </item>
-        <item row="8" column="2">
-         <widget class="QLabel" name="unit_W5">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="in_W6">
-          <property name="text">
-           <string>W6</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="1">
-         <widget class="FloatEdit" name="lf_W6"/>
-        </item>
-        <item row="9" column="2">
-         <widget class="QLabel" name="unit_W6">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="in_W7">
-          <property name="text">
-           <string>W7</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="1">
-         <widget class="FloatEdit" name="lf_W7"/>
-        </item>
-        <item row="10" column="2">
-         <widget class="QLabel" name="unit_W7">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_0" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_1" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_2" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_3" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>568</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_H0">
            <property name="text">
-            <string>Slot suface : ?</string>
+            <string>H0</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_magnet_surface">
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_H0">
            <property name="text">
-            <string>Magnet surface : ?</string>
+            <string>m</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_alpha">
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H1">
            <property name="text">
-            <string>Alpha : ?</string>
+            <string>H1</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_Whole">
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H1">
            <property name="text">
-            <string>Wslot : ?</string>
+            <string>m</string>
            </property>
           </widget>
          </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
            </property>
-          </spacer>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_W1">
+           <property name="cursorPosition">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>rad</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="in_W4">
+           <property name="text">
+            <string>W4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="FloatEdit" name="lf_W4"/>
+         </item>
+         <item row="7" column="2">
+          <widget class="QLabel" name="unit_W4">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="in_W5">
+           <property name="text">
+            <string>W5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="FloatEdit" name="lf_W5"/>
+         </item>
+         <item row="8" column="2">
+          <widget class="QLabel" name="unit_W5">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="in_W6">
+           <property name="text">
+            <string>W6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="FloatEdit" name="lf_W6"/>
+         </item>
+         <item row="9" column="2">
+          <widget class="QLabel" name="unit_W6">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0">
+          <widget class="QLabel" name="in_W7">
+           <property name="text">
+            <string>W7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="FloatEdit" name="lf_W7"/>
+         </item>
+         <item row="10" column="2">
+          <widget class="QLabel" name="unit_W7">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_0" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_1" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_2" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_3" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>7</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Slot suface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_magnet_surface">
+            <property name="text">
+             <string>Magnet surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_alpha">
+            <property name="text">
+             <string>Alpha : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_Whole">
+            <property name="text">
+             <string>Wslot : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM51/Ui_PHoleM51.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM51/Ui_PHoleM51.py
@@ -19,7 +19,7 @@ class Ui_PHoleM51(object):
     def setupUi(self, PHoleM51):
         if not PHoleM51.objectName():
             PHoleM51.setObjectName(u"PHoleM51")
-        PHoleM51.resize(978, 440)
+        PHoleM51.resize(1078, 592)
         PHoleM51.setMinimumSize(QSize(740, 440))
         PHoleM51.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleM51)
@@ -66,214 +66,218 @@ class Ui_PHoleM51(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_3)
 
-        self.widget = QWidget(PHoleM51)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.scrollArea = QScrollArea(PHoleM51)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 568))
+        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
         self.gridLayout.setSizeConstraint(QLayout.SetDefaultConstraint)
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 0, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 0, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 0, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 1, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 1, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 1, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 2, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 2, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 2, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 3, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 3, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 3, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 4, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
         self.lf_W1.setCursorPosition(0)
 
         self.gridLayout.addWidget(self.lf_W1, 4, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 4, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 5, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 5, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 5, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 6, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 6, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 6, 2, 1, 1)
 
-        self.in_W4 = QLabel(self.widget)
+        self.in_W4 = QLabel(self.scrollAreaWidgetContents)
         self.in_W4.setObjectName(u"in_W4")
 
         self.gridLayout.addWidget(self.in_W4, 7, 0, 1, 1)
 
-        self.lf_W4 = FloatEdit(self.widget)
+        self.lf_W4 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W4.setObjectName(u"lf_W4")
 
         self.gridLayout.addWidget(self.lf_W4, 7, 1, 1, 1)
 
-        self.unit_W4 = QLabel(self.widget)
+        self.unit_W4 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W4.setObjectName(u"unit_W4")
 
         self.gridLayout.addWidget(self.unit_W4, 7, 2, 1, 1)
 
-        self.in_W5 = QLabel(self.widget)
+        self.in_W5 = QLabel(self.scrollAreaWidgetContents)
         self.in_W5.setObjectName(u"in_W5")
 
         self.gridLayout.addWidget(self.in_W5, 8, 0, 1, 1)
 
-        self.lf_W5 = FloatEdit(self.widget)
+        self.lf_W5 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W5.setObjectName(u"lf_W5")
 
         self.gridLayout.addWidget(self.lf_W5, 8, 1, 1, 1)
 
-        self.unit_W5 = QLabel(self.widget)
+        self.unit_W5 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W5.setObjectName(u"unit_W5")
 
         self.gridLayout.addWidget(self.unit_W5, 8, 2, 1, 1)
 
-        self.in_W6 = QLabel(self.widget)
+        self.in_W6 = QLabel(self.scrollAreaWidgetContents)
         self.in_W6.setObjectName(u"in_W6")
 
         self.gridLayout.addWidget(self.in_W6, 9, 0, 1, 1)
 
-        self.lf_W6 = FloatEdit(self.widget)
+        self.lf_W6 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W6.setObjectName(u"lf_W6")
 
         self.gridLayout.addWidget(self.lf_W6, 9, 1, 1, 1)
 
-        self.unit_W6 = QLabel(self.widget)
+        self.unit_W6 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W6.setObjectName(u"unit_W6")
 
         self.gridLayout.addWidget(self.unit_W6, 9, 2, 1, 1)
 
-        self.in_W7 = QLabel(self.widget)
+        self.in_W7 = QLabel(self.scrollAreaWidgetContents)
         self.in_W7.setObjectName(u"in_W7")
 
         self.gridLayout.addWidget(self.in_W7, 10, 0, 1, 1)
 
-        self.lf_W7 = FloatEdit(self.widget)
+        self.lf_W7 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W7.setObjectName(u"lf_W7")
 
         self.gridLayout.addWidget(self.lf_W7, 10, 1, 1, 1)
 
-        self.unit_W7 = QLabel(self.widget)
+        self.unit_W7 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W7.setObjectName(u"unit_W7")
 
         self.gridLayout.addWidget(self.unit_W7, 10, 2, 1, 1)
 
-        self.verticalLayout_2.addLayout(self.gridLayout)
+        self.verticalLayout_4.addLayout(self.gridLayout)
 
-        self.w_mat_0 = WMatSelect(self.widget)
+        self.w_mat_0 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_0.setObjectName(u"w_mat_0")
         self.w_mat_0.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_0)
+        self.verticalLayout_4.addWidget(self.w_mat_0)
 
-        self.w_mat_1 = WMatSelect(self.widget)
+        self.w_mat_1 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_1.setObjectName(u"w_mat_1")
         self.w_mat_1.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_1)
+        self.verticalLayout_4.addWidget(self.w_mat_1)
 
-        self.w_mat_2 = WMatSelect(self.widget)
+        self.w_mat_2 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_2.setObjectName(u"w_mat_2")
         self.w_mat_2.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_2)
+        self.verticalLayout_4.addWidget(self.w_mat_2)
 
-        self.w_mat_3 = WMatSelect(self.widget)
+        self.w_mat_3 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_3.setObjectName(u"w_mat_3")
         self.w_mat_3.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_3)
+        self.verticalLayout_4.addWidget(self.w_mat_3)
 
         self.verticalSpacer_2 = QSpacerItem(
-            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
+            20, 7, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout_2.addItem(self.verticalSpacer_2)
+        self.verticalLayout_4.addItem(self.verticalSpacer_2)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -304,9 +308,11 @@ class Ui_PHoleM51(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.verticalLayout_2.addWidget(self.g_output)
+        self.verticalLayout_4.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_H0, self.lf_H1)
         QWidget.setTabOrder(self.lf_H1, self.lf_H2)
@@ -330,10 +336,9 @@ class Ui_PHoleM51(object):
                 '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
                 "p, li { white-space: pre-wrap; }\n"
                 "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;\">\n"
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:14pt;">W3+W2 &lt; W0</span></p>\n'
-                '<p align="center" style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:\'MS '
-                "Shell Dlg 2'; font-size:8pt;\"><br /></p></body></html>",
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">W3+W2 &lt; W0</span></p>\n'
+                '<p align="center" style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"><br /></p></body></html>',
                 None,
             )
         )

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM52/PHoleM52.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM52/PHoleM52.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>940</width>
+    <width>934</width>
     <height>440</height>
    </rect>
   </property>
@@ -87,9 +87,9 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;H2 &amp;lt; H1&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;H2 &amp;lt; H1&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -99,186 +99,199 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_0" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_1" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>416</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_W3">
            <property name="text">
-            <string>Slot suface : ?</string>
+            <string>W3</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_magnet_surface">
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_W3">
            <property name="text">
-            <string>Magnet surface : ?</string>
+            <string>m</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_alpha">
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_H0">
            <property name="text">
-            <string>Alpha : ?</string>
+            <string>H0</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_W1">
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H1">
            <property name="text">
-            <string>W1 : ?</string>
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
            </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_0" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_1" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Slot suface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_magnet_surface">
+            <property name="text">
+             <string>Magnet surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_alpha">
+            <property name="text">
+             <string>Alpha : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_W1">
+            <property name="text">
+             <string>W1 : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM52/Ui_PHoleM52.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM52/Ui_PHoleM52.py
@@ -19,7 +19,7 @@ class Ui_PHoleM52(object):
     def setupUi(self, PHoleM52):
         if not PHoleM52.objectName():
             PHoleM52.setObjectName(u"PHoleM52")
-        PHoleM52.resize(940, 440)
+        PHoleM52.resize(934, 440)
         PHoleM52.setMinimumSize(QSize(740, 440))
         PHoleM52.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleM52)
@@ -62,110 +62,114 @@ class Ui_PHoleM52(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_3)
 
-        self.widget = QWidget(PHoleM52)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.scrollArea = QScrollArea(PHoleM52)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 416))
+        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 4, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 4, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 4, 2, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 0, 1, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 0, 0, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 1, 2, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 1, 1, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 1, 0, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 0, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 2, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 2, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 2, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 3, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 3, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 3, 2, 1, 1)
 
-        self.verticalLayout_2.addLayout(self.gridLayout)
+        self.verticalLayout_4.addLayout(self.gridLayout)
 
-        self.w_mat_0 = WMatSelect(self.widget)
+        self.w_mat_0 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_0.setObjectName(u"w_mat_0")
         self.w_mat_0.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_0)
+        self.verticalLayout_4.addWidget(self.w_mat_0)
 
-        self.w_mat_1 = WMatSelect(self.widget)
+        self.w_mat_1 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_1.setObjectName(u"w_mat_1")
         self.w_mat_1.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_1)
+        self.verticalLayout_4.addWidget(self.w_mat_1)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout_2.addItem(self.verticalSpacer)
+        self.verticalLayout_4.addItem(self.verticalSpacer)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -190,9 +194,11 @@ class Ui_PHoleM52(object):
 
         self.verticalLayout.addWidget(self.out_W1)
 
-        self.verticalLayout_2.addWidget(self.g_output)
+        self.verticalLayout_4.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_H0, self.lf_H1)
         QWidget.setTabOrder(self.lf_H1, self.lf_H2)
@@ -216,10 +222,9 @@ class Ui_PHoleM52(object):
                 '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
                 "p, li { white-space: pre-wrap; }\n"
                 "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;\">\n"
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:14pt;">H2 &lt; H1</span></p>\n'
-                '<p align="center" style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:\'MS She'
-                "ll Dlg 2'; font-size:8pt;\"><br /></p></body></html>",
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">H2 &lt; H1</span></p>\n'
+                '<p align="center" style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"><br /></p></body></html>',
                 None,
             )
         )

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM53/PHoleM53.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM53/PHoleM53.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>967</width>
+    <width>922</width>
     <height>515</height>
    </rect>
   </property>
@@ -87,8 +87,8 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;H2 &amp;lt; H3&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;H2 &amp;lt; H3&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -98,244 +98,257 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H3">
-          <property name="text">
-           <string>H3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H3"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="in_W4">
-          <property name="text">
-           <string>W4</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="FloatEdit" name="lf_W4">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="2">
-         <widget class="QLabel" name="unit_W4">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_0" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_1" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_2" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>74</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>491</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_H0">
            <property name="text">
-            <string>Slot suface (2 part) : ?</string>
+            <string>H0</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_magnet_surface">
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_H0">
            <property name="text">
-            <string>Single Magnet surface : ?</string>
+            <string>m</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_W5">
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H1">
            <property name="text">
-            <string>W5 : ?</string>
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H3">
+           <property name="text">
+            <string>H3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H3"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="in_W4">
+           <property name="text">
+            <string>W4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="FloatEdit" name="lf_W4">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="2">
+          <widget class="QLabel" name="unit_W4">
+           <property name="text">
+            <string>[rad]</string>
            </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_0" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_1" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_2" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>74</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Slot suface (2 part) : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_magnet_surface">
+            <property name="text">
+             <string>Single Magnet surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_W5">
+            <property name="text">
+             <string>W5 : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM53/Ui_PHoleM53.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM53/Ui_PHoleM53.py
@@ -19,7 +19,7 @@ class Ui_PHoleM53(object):
     def setupUi(self, PHoleM53):
         if not PHoleM53.objectName():
             PHoleM53.setObjectName(u"PHoleM53")
-        PHoleM53.resize(967, 515)
+        PHoleM53.resize(922, 515)
         PHoleM53.setMinimumSize(QSize(740, 440))
         PHoleM53.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleM53)
@@ -62,161 +62,165 @@ class Ui_PHoleM53(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_3)
 
-        self.widget = QWidget(PHoleM53)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.scrollArea = QScrollArea(PHoleM53)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 491))
+        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 0, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 0, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 0, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 1, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 1, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 1, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 2, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 2, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 2, 2, 1, 1)
 
-        self.in_H3 = QLabel(self.widget)
+        self.in_H3 = QLabel(self.scrollAreaWidgetContents)
         self.in_H3.setObjectName(u"in_H3")
 
         self.gridLayout.addWidget(self.in_H3, 3, 0, 1, 1)
 
-        self.lf_H3 = FloatEdit(self.widget)
+        self.lf_H3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H3.setObjectName(u"lf_H3")
 
         self.gridLayout.addWidget(self.lf_H3, 3, 1, 1, 1)
 
-        self.unit_H3 = QLabel(self.widget)
+        self.unit_H3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H3.setObjectName(u"unit_H3")
 
         self.gridLayout.addWidget(self.unit_H3, 3, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 4, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 4, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 4, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 5, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 5, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 5, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 6, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 6, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 6, 2, 1, 1)
 
-        self.in_W4 = QLabel(self.widget)
+        self.in_W4 = QLabel(self.scrollAreaWidgetContents)
         self.in_W4.setObjectName(u"in_W4")
 
         self.gridLayout.addWidget(self.in_W4, 7, 0, 1, 1)
 
-        self.lf_W4 = FloatEdit(self.widget)
+        self.lf_W4 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W4.setObjectName(u"lf_W4")
 
         self.gridLayout.addWidget(self.lf_W4, 7, 1, 1, 1)
 
-        self.unit_W4 = QLabel(self.widget)
+        self.unit_W4 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W4.setObjectName(u"unit_W4")
 
         self.gridLayout.addWidget(self.unit_W4, 7, 2, 1, 1)
 
-        self.verticalLayout_2.addLayout(self.gridLayout)
+        self.verticalLayout_4.addLayout(self.gridLayout)
 
-        self.w_mat_0 = WMatSelect(self.widget)
+        self.w_mat_0 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_0.setObjectName(u"w_mat_0")
         self.w_mat_0.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_0)
+        self.verticalLayout_4.addWidget(self.w_mat_0)
 
-        self.w_mat_1 = WMatSelect(self.widget)
+        self.w_mat_1 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_1.setObjectName(u"w_mat_1")
         self.w_mat_1.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_1)
+        self.verticalLayout_4.addWidget(self.w_mat_1)
 
-        self.w_mat_2 = WMatSelect(self.widget)
+        self.w_mat_2 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_2.setObjectName(u"w_mat_2")
         self.w_mat_2.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_2)
+        self.verticalLayout_4.addWidget(self.w_mat_2)
 
         self.verticalSpacer = QSpacerItem(
             20, 74, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout_2.addItem(self.verticalSpacer)
+        self.verticalLayout_4.addItem(self.verticalSpacer)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -236,9 +240,11 @@ class Ui_PHoleM53(object):
 
         self.verticalLayout.addWidget(self.out_W5)
 
-        self.verticalLayout_2.addWidget(self.g_output)
+        self.verticalLayout_4.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_H0, self.lf_H1)
         QWidget.setTabOrder(self.lf_H1, self.lf_H2)
@@ -265,8 +271,8 @@ class Ui_PHoleM53(object):
                 '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
                 "p, li { white-space: pre-wrap; }\n"
                 "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;\">\n"
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:14pt;">H2 &lt; H3</span></p></body></html>',
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">H2 &lt; H3</span></p></body></html>',
                 None,
             )
         )

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM54/PHoleM54.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM54/PHoleM54.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>890</width>
+    <width>1157</width>
     <height>570</height>
    </rect>
   </property>
@@ -87,8 +87,8 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;H0 &amp;lt; R1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;H0 &amp;lt; R1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -98,138 +98,151 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_R1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_R1"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_R1">
-          <property name="text">
-           <string>R1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_0" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>546</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H1">
            <property name="text">
-            <string>Slot suface : ?</string>
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
            </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_0" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Slot suface : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM54/Ui_PHoleM54.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM54/Ui_PHoleM54.py
@@ -19,7 +19,7 @@ class Ui_PHoleM54(object):
     def setupUi(self, PHoleM54):
         if not PHoleM54.objectName():
             PHoleM54.setObjectName(u"PHoleM54")
-        PHoleM54.resize(890, 570)
+        PHoleM54.resize(1157, 570)
         PHoleM54.setMinimumSize(QSize(740, 440))
         PHoleM54.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleM54)
@@ -62,77 +62,81 @@ class Ui_PHoleM54(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_3)
 
-        self.widget = QWidget(PHoleM54)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PHoleM54)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 546))
+        self.verticalLayout_2 = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 1, 2, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 0, 1, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 1, 1, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 1, 0, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 0, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 2, 1, 1, 1)
 
-        self.unit_R1 = QLabel(self.widget)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 3, 2, 1, 1)
 
-        self.lf_R1 = FloatEdit(self.widget)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 3, 1, 1, 1)
 
-        self.in_R1 = QLabel(self.widget)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 3, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 2, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 2, 0, 1, 1)
 
         self.verticalLayout_2.addLayout(self.gridLayout)
 
-        self.w_mat_0 = WMatSelect(self.widget)
+        self.w_mat_0 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_0.setObjectName(u"w_mat_0")
         self.w_mat_0.setMinimumSize(QSize(100, 0))
 
@@ -144,7 +148,7 @@ class Ui_PHoleM54(object):
 
         self.verticalLayout_2.addItem(self.verticalSpacer)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -156,7 +160,9 @@ class Ui_PHoleM54(object):
 
         self.verticalLayout_2.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_H0, self.lf_H1)
         QWidget.setTabOrder(self.lf_H1, self.lf_W0)
@@ -179,8 +185,8 @@ class Ui_PHoleM54(object):
                 '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
                 "p, li { white-space: pre-wrap; }\n"
                 "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;\">\n"
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:14pt;">H0 &lt; R1</span></p></body></html>',
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">H0 &lt; R1</span></p></body></html>',
                 None,
             )
         )

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM57/PHoleM57.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM57/PHoleM57.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>731</width>
-    <height>470</height>
+    <width>1099</width>
+    <height>491</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -58,220 +58,233 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_W4">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_W4">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_W4">
-          <property name="text">
-           <string>W4</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_0" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_1" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_2" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>467</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_W1">
            <property name="text">
-            <string>Slot suface (2 part) : ?</string>
+            <string>W1</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_magnet_surface">
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_W1">
            <property name="text">
-            <string>Single Magnet surface : ?</string>
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_W4">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_W4">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_W4">
+           <property name="text">
+            <string>W4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
            </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_0" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_1" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_2" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Slot suface (2 part) : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_magnet_surface">
+            <property name="text">
+             <string>Single Magnet surface : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM57/Ui_PHoleM57.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM57/Ui_PHoleM57.py
@@ -19,7 +19,7 @@ class Ui_PHoleM57(object):
     def setupUi(self, PHoleM57):
         if not PHoleM57.objectName():
             PHoleM57.setObjectName(u"PHoleM57")
-        PHoleM57.resize(731, 470)
+        PHoleM57.resize(1099, 491)
         PHoleM57.setMinimumSize(QSize(0, 0))
         PHoleM57.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleM57)
@@ -40,146 +40,150 @@ class Ui_PHoleM57(object):
 
         self.horizontalLayout.addWidget(self.img_slot)
 
-        self.widget = QWidget(PHoleM57)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.scrollArea = QScrollArea(PHoleM57)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 467))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 5, 1, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 2, 1, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 3, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 3, 2, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 0, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 4, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 5, 0, 1, 1)
 
-        self.unit_W4 = QLabel(self.widget)
+        self.unit_W4 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W4.setObjectName(u"unit_W4")
 
         self.gridLayout.addWidget(self.unit_W4, 6, 2, 1, 1)
 
-        self.lf_W4 = FloatEdit(self.widget)
+        self.lf_W4 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W4.setObjectName(u"lf_W4")
 
         self.gridLayout.addWidget(self.lf_W4, 6, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 2, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 4, 0, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 2, 0, 1, 1)
 
-        self.in_W4 = QLabel(self.widget)
+        self.in_W4 = QLabel(self.scrollAreaWidgetContents)
         self.in_W4.setObjectName(u"in_W4")
 
         self.gridLayout.addWidget(self.in_W4, 6, 0, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 0, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 1, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 4, 1, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 0, 0, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 5, 2, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 3, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 1, 2, 1, 1)
 
-        self.verticalLayout_2.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
-        self.w_mat_0 = WMatSelect(self.widget)
+        self.w_mat_0 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_0.setObjectName(u"w_mat_0")
         self.w_mat_0.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_0)
+        self.verticalLayout_3.addWidget(self.w_mat_0)
 
-        self.w_mat_1 = WMatSelect(self.widget)
+        self.w_mat_1 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_1.setObjectName(u"w_mat_1")
         self.w_mat_1.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_1)
+        self.verticalLayout_3.addWidget(self.w_mat_1)
 
-        self.w_mat_2 = WMatSelect(self.widget)
+        self.w_mat_2 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_2.setObjectName(u"w_mat_2")
         self.w_mat_2.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_2)
+        self.verticalLayout_3.addWidget(self.w_mat_2)
 
         self.verticalSpacer_2 = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout_2.addItem(self.verticalSpacer_2)
+        self.verticalLayout_3.addItem(self.verticalSpacer_2)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -194,9 +198,11 @@ class Ui_PHoleM57(object):
 
         self.verticalLayout.addWidget(self.out_magnet_surface)
 
-        self.verticalLayout_2.addWidget(self.g_output)
+        self.verticalLayout_3.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_H1, self.lf_H2)
         QWidget.setTabOrder(self.lf_H2, self.lf_W0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM58/PHoleM58.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM58/PHoleM58.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>963</width>
-    <height>549</height>
+    <width>1304</width>
+    <height>529</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -87,8 +87,8 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
-&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:14pt;&quot;&gt;W1 + W2 &amp;lt; W0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; text-decoration: underline;&quot;&gt;Constraints :&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;W1 + W2 &amp;lt; W0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -98,227 +98,240 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="7" column="2">
-         <widget class="QLabel" name="unit_R0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="in_R0">
-          <property name="text">
-           <string>R0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="7" column="1">
-         <widget class="FloatEdit" name="lf_R0">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_0" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WMatSelect" name="w_mat_1" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>176</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>505</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_H0">
            <property name="text">
-            <string>Hole suface : ?</string>
+            <string>H0</string>
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QLabel" name="out_magnet_surface">
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="7" column="2">
+          <widget class="QLabel" name="unit_R0">
            <property name="text">
-            <string>Magnet surface : ?</string>
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="in_R0">
+           <property name="text">
+            <string>R0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="7" column="1">
+          <widget class="FloatEdit" name="lf_R0">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>[rad]</string>
            </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_0" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WMatSelect" name="w_mat_1" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>176</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Hole suface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_magnet_surface">
+            <property name="text">
+             <string>Magnet surface : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM58/Ui_PHoleM58.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleM58/Ui_PHoleM58.py
@@ -19,7 +19,7 @@ class Ui_PHoleM58(object):
     def setupUi(self, PHoleM58):
         if not PHoleM58.objectName():
             PHoleM58.setObjectName(u"PHoleM58")
-        PHoleM58.resize(963, 549)
+        PHoleM58.resize(1304, 529)
         PHoleM58.setMinimumSize(QSize(740, 440))
         PHoleM58.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleM58)
@@ -62,155 +62,159 @@ class Ui_PHoleM58(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_3)
 
-        self.widget = QWidget(PHoleM58)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.scrollArea = QScrollArea(PHoleM58)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 505))
+        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 0, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 0, 1, 1, 1)
 
-        self.unit_R0 = QLabel(self.widget)
+        self.unit_R0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R0.setObjectName(u"unit_R0")
 
         self.gridLayout.addWidget(self.unit_R0, 7, 2, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 0, 2, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 5, 2, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 3, 2, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 4, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 6, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 3, 1, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 4, 0, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 5, 0, 1, 1)
 
-        self.in_R0 = QLabel(self.widget)
+        self.in_R0 = QLabel(self.scrollAreaWidgetContents)
         self.in_R0.setObjectName(u"in_R0")
 
         self.gridLayout.addWidget(self.in_R0, 7, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 4, 1, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 1, 0, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 5, 1, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 3, 0, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 2, 2, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 6, 1, 1, 1)
 
-        self.lf_R0 = FloatEdit(self.widget)
+        self.lf_R0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R0.setObjectName(u"lf_R0")
 
         self.gridLayout.addWidget(self.lf_R0, 7, 1, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 1, 1, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 2, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 1, 2, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 6, 2, 1, 1)
 
-        self.verticalLayout_2.addLayout(self.gridLayout)
+        self.verticalLayout_4.addLayout(self.gridLayout)
 
-        self.w_mat_0 = WMatSelect(self.widget)
+        self.w_mat_0 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_0.setObjectName(u"w_mat_0")
         self.w_mat_0.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_0)
+        self.verticalLayout_4.addWidget(self.w_mat_0)
 
-        self.w_mat_1 = WMatSelect(self.widget)
+        self.w_mat_1 = WMatSelect(self.scrollAreaWidgetContents)
         self.w_mat_1.setObjectName(u"w_mat_1")
         self.w_mat_1.setMinimumSize(QSize(100, 0))
 
-        self.verticalLayout_2.addWidget(self.w_mat_1)
+        self.verticalLayout_4.addWidget(self.w_mat_1)
 
         self.verticalSpacer = QSpacerItem(
             20, 176, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout_2.addItem(self.verticalSpacer)
+        self.verticalLayout_4.addItem(self.verticalSpacer)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -225,9 +229,11 @@ class Ui_PHoleM58(object):
 
         self.verticalLayout.addWidget(self.out_magnet_surface)
 
-        self.verticalLayout_2.addWidget(self.g_output)
+        self.verticalLayout_4.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_H0, self.lf_H1)
         QWidget.setTabOrder(self.lf_H1, self.lf_H2)
@@ -254,8 +260,8 @@ class Ui_PHoleM58(object):
                 '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
                 "p, li { white-space: pre-wrap; }\n"
                 "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;\">\n"
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
-                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:\'MS Shell Dlg 2\'; font-size:14pt;">W1 + W2 &lt; W0</span></p></body></html>',
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:12pt; font-weight:600; text-decoration: underline;">Constraints :</span></p>\n'
+                '<p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:14pt;">W1 + W2 &lt; W0</span></p></body></html>',
                 None,
             )
         )

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleMUD/PHoleMUD.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleMUD/PHoleMUD.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>813</width>
-    <height>467</height>
+    <width>1103</width>
+    <height>588</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -30,113 +30,126 @@
     <widget class="MPLCanvas2" name="w_viewer" native="true"/>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QPushButton" name="b_dxf">
-        <property name="text">
-         <string>Define Hole from DXF</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WPathSelectorV" name="w_path_json" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_mat">
-        <property name="title">
-         <string>Materials</string>
-        </property>
-        <layout class="QVBoxLayout" name="g_mat_layout">
-         <item>
-          <widget class="WMatSelect" name="w_mat_0" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>179</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_output">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Output</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="out_slot_surface">
-           <property name="text">
-            <string>Hole full surface : ?</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="out_magnet_surface">
-           <property name="text">
-            <string>Hole magnet surface : ?</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="out_Rmin">
-           <property name="text">
-            <string>Rmin : ?</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="out_Rmax">
-           <property name="text">
-            <string>Rmax : ?</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>564</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QPushButton" name="b_dxf">
+         <property name="text">
+          <string>Define Hole from DXF</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WPathSelectorV" name="w_path_json" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_mat">
+         <property name="title">
+          <string>Materials</string>
+         </property>
+         <layout class="QVBoxLayout" name="g_mat_layout">
+          <item>
+           <widget class="WMatSelect" name="w_mat_0" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>179</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="out_slot_surface">
+            <property name="text">
+             <string>Hole full surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_magnet_surface">
+            <property name="text">
+             <string>Hole magnet surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_Rmin">
+            <property name="text">
+             <string>Rmin : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_Rmax">
+            <property name="text">
+             <string>Rmax : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleMUD/Ui_PHoleMUD.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMHoleMag/PHoleMUD/Ui_PHoleMUD.py
@@ -20,7 +20,7 @@ class Ui_PHoleMUD(object):
     def setupUi(self, PHoleMUD):
         if not PHoleMUD.objectName():
             PHoleMUD.setObjectName(u"PHoleMUD")
-        PHoleMUD.resize(813, 467)
+        PHoleMUD.resize(1103, 588)
         PHoleMUD.setMinimumSize(QSize(740, 440))
         PHoleMUD.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PHoleMUD)
@@ -30,18 +30,22 @@ class Ui_PHoleMUD(object):
 
         self.horizontalLayout.addWidget(self.w_viewer)
 
-        self.widget = QWidget(PHoleMUD)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_2 = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PHoleMUD)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 564))
+        self.verticalLayout_2 = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
-        self.b_dxf = QPushButton(self.widget)
+        self.b_dxf = QPushButton(self.scrollAreaWidgetContents)
         self.b_dxf.setObjectName(u"b_dxf")
 
         self.verticalLayout_2.addWidget(self.b_dxf)
 
-        self.w_path_json = WPathSelectorV(self.widget)
+        self.w_path_json = WPathSelectorV(self.scrollAreaWidgetContents)
         self.w_path_json.setObjectName(u"w_path_json")
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
@@ -51,7 +55,7 @@ class Ui_PHoleMUD(object):
 
         self.verticalLayout_2.addWidget(self.w_path_json)
 
-        self.g_mat = QGroupBox(self.widget)
+        self.g_mat = QGroupBox(self.scrollAreaWidgetContents)
         self.g_mat.setObjectName(u"g_mat")
         self.g_mat_layout = QVBoxLayout(self.g_mat)
         self.g_mat_layout.setObjectName(u"g_mat_layout")
@@ -69,7 +73,7 @@ class Ui_PHoleMUD(object):
 
         self.verticalLayout_2.addItem(self.verticalSpacer)
 
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout = QVBoxLayout(self.g_output)
@@ -96,7 +100,9 @@ class Ui_PHoleMUD(object):
 
         self.verticalLayout_2.addWidget(self.g_output)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         self.retranslateUi(PHoleMUD)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot10/PMSlot10.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot10/PMSlot10.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>948</width>
+    <width>929</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,109 +86,122 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Wmag">
-          <property name="text">
-           <string>Wmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_Wmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Hmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Hmag">
-          <property name="text">
-           <string>Hmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Hmag"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_Wmag"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Wmag">
+           <property name="text">
+            <string>Wmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_Wmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Hmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Hmag">
+           <property name="text">
+            <string>Hmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Hmag"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_Wmag"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot10/Ui_PMSlot10.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot10/Ui_PMSlot10.py
@@ -19,7 +19,7 @@ class Ui_PMSlot10(object):
     def setupUi(self, PMSlot10):
         if not PMSlot10.objectName():
             PMSlot10.setObjectName(u"PMSlot10")
-        PMSlot10.resize(948, 470)
+        PMSlot10.resize(929, 470)
         PMSlot10.setMinimumSize(QSize(630, 470))
         PMSlot10.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot10)
@@ -60,88 +60,94 @@ class Ui_PMSlot10(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot10)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PMSlot10)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_Wmag = QLabel(self.widget)
+        self.in_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Wmag.setObjectName(u"in_Wmag")
 
         self.gridLayout.addWidget(self.in_Wmag, 1, 0, 1, 1)
 
-        self.unit_Wmag = QLabel(self.widget)
+        self.unit_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wmag.setObjectName(u"unit_Wmag")
 
         self.gridLayout.addWidget(self.unit_Wmag, 1, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.unit_Hmag = QLabel(self.widget)
+        self.unit_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Hmag.setObjectName(u"unit_Hmag")
 
         self.gridLayout.addWidget(self.unit_Hmag, 3, 2, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.in_Hmag = QLabel(self.widget)
+        self.in_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Hmag.setObjectName(u"in_Hmag")
 
         self.gridLayout.addWidget(self.in_Hmag, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.lf_Hmag = FloatEdit(self.widget)
+        self.lf_Hmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Hmag.setObjectName(u"lf_Hmag")
 
         self.gridLayout.addWidget(self.lf_Hmag, 3, 1, 1, 1)
 
-        self.lf_Wmag = FloatEdit(self.widget)
+        self.lf_Wmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wmag.setObjectName(u"lf_Wmag")
 
         self.gridLayout.addWidget(self.lf_Wmag, 1, 1, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_3.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_3.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_Wmag)
         QWidget.setTabOrder(self.lf_Wmag, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot11/PMSlot11.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot11/PMSlot11.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>826</width>
+    <width>877</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,116 +86,129 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Wmag">
-          <property name="text">
-           <string>Wmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_Wmag">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Hmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0">
-          <property name="minimumSize">
-           <size>
-            <width>90</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Hmag">
-          <property name="text">
-           <string>Hmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Hmag"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_Wmag"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Wmag">
+           <property name="text">
+            <string>Wmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_Wmag">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Hmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Hmag">
+           <property name="text">
+            <string>Hmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Hmag"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_Wmag"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot11/Ui_PMSlot11.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot11/Ui_PMSlot11.py
@@ -19,7 +19,7 @@ class Ui_PMSlot11(object):
     def setupUi(self, PMSlot11):
         if not PMSlot11.objectName():
             PMSlot11.setObjectName(u"PMSlot11")
-        PMSlot11.resize(826, 470)
+        PMSlot11.resize(877, 470)
         PMSlot11.setMinimumSize(QSize(630, 470))
         PMSlot11.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot11)
@@ -60,71 +60,75 @@ class Ui_PMSlot11(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot11)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PMSlot11)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_Wmag = QLabel(self.widget)
+        self.in_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Wmag.setObjectName(u"in_Wmag")
 
         self.gridLayout.addWidget(self.in_Wmag, 1, 0, 1, 1)
 
-        self.unit_Wmag = QLabel(self.widget)
+        self.unit_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wmag.setObjectName(u"unit_Wmag")
 
         self.gridLayout.addWidget(self.unit_Wmag, 1, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.unit_Hmag = QLabel(self.widget)
+        self.unit_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Hmag.setObjectName(u"unit_Hmag")
 
         self.gridLayout.addWidget(self.unit_Hmag, 3, 2, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
         self.lf_W0.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.in_Hmag = QLabel(self.widget)
+        self.in_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Hmag.setObjectName(u"in_Hmag")
 
         self.gridLayout.addWidget(self.in_Hmag, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.lf_Hmag = FloatEdit(self.widget)
+        self.lf_Hmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Hmag.setObjectName(u"lf_Hmag")
 
         self.gridLayout.addWidget(self.lf_Hmag, 3, 1, 1, 1)
 
-        self.lf_Wmag = FloatEdit(self.widget)
+        self.lf_Wmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wmag.setObjectName(u"lf_Wmag")
 
         self.gridLayout.addWidget(self.lf_Wmag, 1, 1, 1, 1)
@@ -137,12 +141,14 @@ class Ui_PMSlot11(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_Wmag)
         QWidget.setTabOrder(self.lf_Wmag, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot12/PMSlot12.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot12/PMSlot12.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>909</width>
+    <width>830</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,109 +86,122 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Wmag">
-          <property name="text">
-           <string>Wmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_Wmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Hmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Hmag">
-          <property name="text">
-           <string>Hmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Hmag"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_Wmag"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Wmag">
+           <property name="text">
+            <string>Wmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_Wmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Hmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Hmag">
+           <property name="text">
+            <string>Hmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Hmag"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_Wmag"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot12/Ui_PMSlot12.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot12/Ui_PMSlot12.py
@@ -19,7 +19,7 @@ class Ui_PMSlot12(object):
     def setupUi(self, PMSlot12):
         if not PMSlot12.objectName():
             PMSlot12.setObjectName(u"PMSlot12")
-        PMSlot12.resize(909, 470)
+        PMSlot12.resize(830, 470)
         PMSlot12.setMinimumSize(QSize(630, 470))
         PMSlot12.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot12)
@@ -60,88 +60,94 @@ class Ui_PMSlot12(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot12)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PMSlot12)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_Wmag = QLabel(self.widget)
+        self.in_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Wmag.setObjectName(u"in_Wmag")
 
         self.gridLayout.addWidget(self.in_Wmag, 1, 0, 1, 1)
 
-        self.unit_Wmag = QLabel(self.widget)
+        self.unit_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wmag.setObjectName(u"unit_Wmag")
 
         self.gridLayout.addWidget(self.unit_Wmag, 1, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.unit_Hmag = QLabel(self.widget)
+        self.unit_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Hmag.setObjectName(u"unit_Hmag")
 
         self.gridLayout.addWidget(self.unit_Hmag, 3, 2, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.in_Hmag = QLabel(self.widget)
+        self.in_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Hmag.setObjectName(u"in_Hmag")
 
         self.gridLayout.addWidget(self.in_Hmag, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.lf_Hmag = FloatEdit(self.widget)
+        self.lf_Hmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Hmag.setObjectName(u"lf_Hmag")
 
         self.gridLayout.addWidget(self.lf_Hmag, 3, 1, 1, 1)
 
-        self.lf_Wmag = FloatEdit(self.widget)
+        self.lf_Wmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wmag.setObjectName(u"lf_Wmag")
 
         self.gridLayout.addWidget(self.lf_Wmag, 1, 1, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_3.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_3.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_Wmag)
         QWidget.setTabOrder(self.lf_Wmag, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot13/PMSlot13.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot13/PMSlot13.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1166</width>
+    <width>899</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,126 +86,139 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Wmag">
-          <property name="text">
-           <string>Wmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_Wmag"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_Wmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Hmag">
-          <property name="text">
-           <string>Hmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Hmag"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Hmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_Rtopm">
-          <property name="text">
-           <string>Rtopm</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_Rtopm"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_Rtopm">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Wmag">
+           <property name="text">
+            <string>Wmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_Wmag"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_Wmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Hmag">
+           <property name="text">
+            <string>Hmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Hmag"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Hmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_Rtopm">
+           <property name="text">
+            <string>Rtopm</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_Rtopm"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_Rtopm">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot13/Ui_PMSlot13.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot13/Ui_PMSlot13.py
@@ -19,7 +19,7 @@ class Ui_PMSlot13(object):
     def setupUi(self, PMSlot13):
         if not PMSlot13.objectName():
             PMSlot13.setObjectName(u"PMSlot13")
-        PMSlot13.resize(1166, 470)
+        PMSlot13.resize(899, 470)
         PMSlot13.setMinimumSize(QSize(630, 470))
         PMSlot13.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot13)
@@ -60,103 +60,109 @@ class Ui_PMSlot13(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot13)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PMSlot13)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_Wmag = QLabel(self.widget)
+        self.in_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Wmag.setObjectName(u"in_Wmag")
 
         self.gridLayout.addWidget(self.in_Wmag, 1, 0, 1, 1)
 
-        self.lf_Wmag = FloatEdit(self.widget)
+        self.lf_Wmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wmag.setObjectName(u"lf_Wmag")
 
         self.gridLayout.addWidget(self.lf_Wmag, 1, 1, 1, 1)
 
-        self.unit_Wmag = QLabel(self.widget)
+        self.unit_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wmag.setObjectName(u"unit_Wmag")
 
         self.gridLayout.addWidget(self.unit_Wmag, 1, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_Hmag = QLabel(self.widget)
+        self.in_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Hmag.setObjectName(u"in_Hmag")
 
         self.gridLayout.addWidget(self.in_Hmag, 3, 0, 1, 1)
 
-        self.lf_Hmag = FloatEdit(self.widget)
+        self.lf_Hmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Hmag.setObjectName(u"lf_Hmag")
 
         self.gridLayout.addWidget(self.lf_Hmag, 3, 1, 1, 1)
 
-        self.unit_Hmag = QLabel(self.widget)
+        self.unit_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Hmag.setObjectName(u"unit_Hmag")
 
         self.gridLayout.addWidget(self.unit_Hmag, 3, 2, 1, 1)
 
-        self.in_Rtopm = QLabel(self.widget)
+        self.in_Rtopm = QLabel(self.scrollAreaWidgetContents)
         self.in_Rtopm.setObjectName(u"in_Rtopm")
 
         self.gridLayout.addWidget(self.in_Rtopm, 4, 0, 1, 1)
 
-        self.lf_Rtopm = FloatEdit(self.widget)
+        self.lf_Rtopm = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Rtopm.setObjectName(u"lf_Rtopm")
 
         self.gridLayout.addWidget(self.lf_Rtopm, 4, 1, 1, 1)
 
-        self.unit_Rtopm = QLabel(self.widget)
+        self.unit_Rtopm = QLabel(self.scrollAreaWidgetContents)
         self.unit_Rtopm.setObjectName(u"unit_Rtopm")
 
         self.gridLayout.addWidget(self.unit_Rtopm, 4, 2, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_3.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_3.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_Wmag)
         QWidget.setTabOrder(self.lf_Wmag, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot14/PMSlot14.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot14/PMSlot14.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1055</width>
+    <width>823</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,126 +86,139 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Wmag">
-          <property name="text">
-           <string>Wmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_Wmag"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_Wmag">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Hmag">
-          <property name="text">
-           <string>Hmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Hmag"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Hmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_Rtopm">
-          <property name="text">
-           <string>Rtopm</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_Rtopm"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_Rtopm">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Wmag">
+           <property name="text">
+            <string>Wmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_Wmag"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_Wmag">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Hmag">
+           <property name="text">
+            <string>Hmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Hmag"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Hmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_Rtopm">
+           <property name="text">
+            <string>Rtopm</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_Rtopm"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_Rtopm">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot14/Ui_PMSlot14.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot14/Ui_PMSlot14.py
@@ -19,7 +19,7 @@ class Ui_PMSlot14(object):
     def setupUi(self, PMSlot14):
         if not PMSlot14.objectName():
             PMSlot14.setObjectName(u"PMSlot14")
-        PMSlot14.resize(1055, 470)
+        PMSlot14.resize(823, 470)
         PMSlot14.setMinimumSize(QSize(630, 470))
         PMSlot14.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot14)
@@ -60,103 +60,109 @@ class Ui_PMSlot14(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot14)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PMSlot14)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_Wmag = QLabel(self.widget)
+        self.in_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Wmag.setObjectName(u"in_Wmag")
 
         self.gridLayout.addWidget(self.in_Wmag, 1, 0, 1, 1)
 
-        self.lf_Wmag = FloatEdit(self.widget)
+        self.lf_Wmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wmag.setObjectName(u"lf_Wmag")
 
         self.gridLayout.addWidget(self.lf_Wmag, 1, 1, 1, 1)
 
-        self.unit_Wmag = QLabel(self.widget)
+        self.unit_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wmag.setObjectName(u"unit_Wmag")
 
         self.gridLayout.addWidget(self.unit_Wmag, 1, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_Hmag = QLabel(self.widget)
+        self.in_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Hmag.setObjectName(u"in_Hmag")
 
         self.gridLayout.addWidget(self.in_Hmag, 3, 0, 1, 1)
 
-        self.lf_Hmag = FloatEdit(self.widget)
+        self.lf_Hmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Hmag.setObjectName(u"lf_Hmag")
 
         self.gridLayout.addWidget(self.lf_Hmag, 3, 1, 1, 1)
 
-        self.unit_Hmag = QLabel(self.widget)
+        self.unit_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Hmag.setObjectName(u"unit_Hmag")
 
         self.gridLayout.addWidget(self.unit_Hmag, 3, 2, 1, 1)
 
-        self.in_Rtopm = QLabel(self.widget)
+        self.in_Rtopm = QLabel(self.scrollAreaWidgetContents)
         self.in_Rtopm.setObjectName(u"in_Rtopm")
 
         self.gridLayout.addWidget(self.in_Rtopm, 4, 0, 1, 1)
 
-        self.lf_Rtopm = FloatEdit(self.widget)
+        self.lf_Rtopm = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Rtopm.setObjectName(u"lf_Rtopm")
 
         self.gridLayout.addWidget(self.lf_Rtopm, 4, 1, 1, 1)
 
-        self.unit_Rtopm = QLabel(self.widget)
+        self.unit_Rtopm = QLabel(self.scrollAreaWidgetContents)
         self.unit_Rtopm.setObjectName(u"unit_Rtopm")
 
         self.gridLayout.addWidget(self.unit_Rtopm, 4, 2, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_3.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_3.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_Wmag)
         QWidget.setTabOrder(self.lf_Wmag, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot15/PMSlot15.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot15/PMSlot15.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1055</width>
+    <width>878</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,126 +86,139 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Wmag">
-          <property name="text">
-           <string>Wmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_Wmag"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_Wmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Hmag">
-          <property name="text">
-           <string>Hmag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Hmag"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Hmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_Rtopm">
-          <property name="text">
-           <string>Rtopm</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_Rtopm"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_Rtopm">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Wmag">
+           <property name="text">
+            <string>Wmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_Wmag"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_Wmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Hmag">
+           <property name="text">
+            <string>Hmag</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Hmag"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Hmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_Rtopm">
+           <property name="text">
+            <string>Rtopm</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_Rtopm"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_Rtopm">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot15/Ui_PMSlot15.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot15/Ui_PMSlot15.py
@@ -19,7 +19,7 @@ class Ui_PMSlot15(object):
     def setupUi(self, PMSlot15):
         if not PMSlot15.objectName():
             PMSlot15.setObjectName(u"PMSlot15")
-        PMSlot15.resize(1055, 470)
+        PMSlot15.resize(878, 470)
         PMSlot15.setMinimumSize(QSize(630, 470))
         PMSlot15.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot15)
@@ -60,85 +60,89 @@ class Ui_PMSlot15(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot15)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PMSlot15)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_Wmag = QLabel(self.widget)
+        self.in_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Wmag.setObjectName(u"in_Wmag")
 
         self.gridLayout.addWidget(self.in_Wmag, 1, 0, 1, 1)
 
-        self.lf_Wmag = FloatEdit(self.widget)
+        self.lf_Wmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wmag.setObjectName(u"lf_Wmag")
 
         self.gridLayout.addWidget(self.lf_Wmag, 1, 1, 1, 1)
 
-        self.unit_Wmag = QLabel(self.widget)
+        self.unit_Wmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wmag.setObjectName(u"unit_Wmag")
 
         self.gridLayout.addWidget(self.unit_Wmag, 1, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_Hmag = QLabel(self.widget)
+        self.in_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Hmag.setObjectName(u"in_Hmag")
 
         self.gridLayout.addWidget(self.in_Hmag, 3, 0, 1, 1)
 
-        self.lf_Hmag = FloatEdit(self.widget)
+        self.lf_Hmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Hmag.setObjectName(u"lf_Hmag")
 
         self.gridLayout.addWidget(self.lf_Hmag, 3, 1, 1, 1)
 
-        self.unit_Hmag = QLabel(self.widget)
+        self.unit_Hmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Hmag.setObjectName(u"unit_Hmag")
 
         self.gridLayout.addWidget(self.unit_Hmag, 3, 2, 1, 1)
 
-        self.in_Rtopm = QLabel(self.widget)
+        self.in_Rtopm = QLabel(self.scrollAreaWidgetContents)
         self.in_Rtopm.setObjectName(u"in_Rtopm")
 
         self.gridLayout.addWidget(self.in_Rtopm, 4, 0, 1, 1)
 
-        self.lf_Rtopm = FloatEdit(self.widget)
+        self.lf_Rtopm = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Rtopm.setObjectName(u"lf_Rtopm")
 
         self.gridLayout.addWidget(self.lf_Rtopm, 4, 1, 1, 1)
 
-        self.unit_Rtopm = QLabel(self.widget)
+        self.unit_Rtopm = QLabel(self.scrollAreaWidgetContents)
         self.unit_Rtopm.setObjectName(u"unit_Rtopm")
 
         self.gridLayout.addWidget(self.unit_Rtopm, 4, 2, 1, 1)
@@ -151,12 +155,14 @@ class Ui_PMSlot15(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_Wmag)
         QWidget.setTabOrder(self.lf_Wmag, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot16/PMSlot16.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot16/PMSlot16.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>948</width>
+    <width>871</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,109 +86,122 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot16/Ui_PMSlot16.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot16/Ui_PMSlot16.py
@@ -19,7 +19,7 @@ class Ui_PMSlot16(object):
     def setupUi(self, PMSlot16):
         if not PMSlot16.objectName():
             PMSlot16.setObjectName(u"PMSlot16")
-        PMSlot16.resize(948, 470)
+        PMSlot16.resize(871, 470)
         PMSlot16.setMinimumSize(QSize(630, 470))
         PMSlot16.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot16)
@@ -60,70 +60,74 @@ class Ui_PMSlot16(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot16)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PMSlot16)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 3, 2, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 3, 1, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
@@ -136,12 +140,14 @@ class Ui_PMSlot16(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot17/PMSlot17.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot17/PMSlot17.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1055</width>
+    <width>887</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,58 +86,71 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_Lmag">
-          <property name="text">
-           <string>[m]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_Lmag"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_Lmag">
-          <property name="text">
-           <string>Lmag</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_Lmag">
+           <property name="text">
+            <string>[m]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_Lmag"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_Lmag">
+           <property name="text">
+            <string>Lmag</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot17/Ui_PMSlot17.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/PMSlot17/Ui_PMSlot17.py
@@ -19,7 +19,7 @@ class Ui_PMSlot17(object):
     def setupUi(self, PMSlot17):
         if not PMSlot17.objectName():
             PMSlot17.setObjectName(u"PMSlot17")
-        PMSlot17.resize(1055, 470)
+        PMSlot17.resize(887, 470)
         PMSlot17.setMinimumSize(QSize(630, 470))
         PMSlot17.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PMSlot17)
@@ -60,25 +60,29 @@ class Ui_PMSlot17(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PMSlot17)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PMSlot17)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.unit_Lmag = QLabel(self.widget)
+        self.unit_Lmag = QLabel(self.scrollAreaWidgetContents)
         self.unit_Lmag.setObjectName(u"unit_Lmag")
 
         self.gridLayout.addWidget(self.unit_Lmag, 0, 2, 1, 1)
 
-        self.lf_Lmag = FloatEdit(self.widget)
+        self.lf_Lmag = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Lmag.setObjectName(u"lf_Lmag")
 
         self.gridLayout.addWidget(self.lf_Lmag, 0, 1, 1, 1)
 
-        self.in_Lmag = QLabel(self.widget)
+        self.in_Lmag = QLabel(self.scrollAreaWidgetContents)
         self.in_Lmag.setObjectName(u"in_Lmag")
 
         self.gridLayout.addWidget(self.in_Lmag, 0, 0, 1, 1)
@@ -91,12 +95,14 @@ class Ui_PMSlot17(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_Lmag, self.txt_constraint)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/SMSlot.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/SMSlot.ui
@@ -13,7 +13,7 @@
   <property name="minimumSize">
    <size>
     <width>650</width>
-    <height>550</height>
+    <height>0</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/Ui_SMSlot.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMSlot/Ui_SMSlot.py
@@ -20,7 +20,7 @@ class Ui_SMSlot(object):
         if not SMSlot.objectName():
             SMSlot.setObjectName(u"SMSlot")
         SMSlot.resize(650, 550)
-        SMSlot.setMinimumSize(QSize(650, 550))
+        SMSlot.setMinimumSize(QSize(650, 0))
         self.main_layout = QVBoxLayout(SMSlot)
         self.main_layout.setObjectName(u"main_layout")
         self.horizontalLayout_2 = QHBoxLayout()

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMachineDimension/SMachineDimension.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMachineDimension/SMachineDimension.py
@@ -123,7 +123,7 @@ class SMachineDimension(Ui_SMachineDimension, QWidget):
             self.g_shaft.setChecked(True)
             self.machine.shaft.Drsh = self.machine.rotor.Rint * 2
             self.out_Drsh.setText(
-                self.tr("Drsh = 2*Rotor.Rint = ")
+                self.tr("Drsh = ")
                 + format(gui_option.unit.get_m(self.machine.shaft.Drsh), ".4g")
                 + " ["
                 + gui_option.unit.get_m_name()
@@ -311,14 +311,14 @@ class SMachineDimension(Ui_SMachineDimension, QWidget):
                 self.machine.shaft._set_None()
                 self.machine.shaft.Drsh = self.machine.rotor.Rint * 2
                 self.out_Drsh.setText(
-                    self.tr("Drsh = 2*Rotor.Rint = ")
+                    self.tr("Drsh = ")
                     + format(gui_option.unit.get_m(self.machine.shaft.Drsh), ".4g")
                     + " ["
                     + gui_option.unit.get_m_name()
                     + "]"
                 )
             else:
-                self.out_Drsh.setText(self.tr("Drsh = 2*Rotor.Rint = "))
+                self.out_Drsh.setText(self.tr("Drsh = "))
                 self.machine.shaft.Drsh = None
             self.w_mat_0.update(self.machine.shaft, "mat_type", self.matlib)
             # machine.rotor.Rint editable only if there is a shaft

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMachineDimension/SMachineDimension.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMachineDimension/SMachineDimension.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>919</width>
-    <height>550</height>
+    <width>1065</width>
+    <height>679</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -19,449 +19,466 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QLabel" name="img_machine">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="pixmap">
-      <pixmap resource="../../../Resources/pyleecan.qrc">:/images/images/MachineSetup/MachineDimension/Dimension_Shaft_Rotor_Stator.png</pixmap>
-     </property>
-     <property name="scaledContents">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="img_machine">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../../../Resources/pyleecan.qrc">:/images/images/MachineSetup/MachineDimension/Dimension_Shaft_Rotor_Stator.png</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QScrollArea" name="scrollArea">
+       <property name="minimumSize">
+        <size>
+         <width>270</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>270</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>268</width>
+          <height>616</height>
+         </rect>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QGroupBox" name="g_stator">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Stator</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="in_SRext">
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Stator external radius</string>
+              </property>
+              <property name="text">
+               <string>Rext</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="FloatEdit" name="lf_SRext">
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Stator external radius</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="unit_SRext">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>m</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="in_SRint">
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Stator internal radius</string>
+              </property>
+              <property name="text">
+               <string>Rint</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="FloatEdit" name="lf_SRint">
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>100</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Stator internal radius</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLabel" name="unit_SRint">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>m</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="g_rotor">
+           <property name="title">
+            <string>Rotor</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="0" column="0">
+             <widget class="QLabel" name="in_RRext">
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Rotor external radius</string>
+              </property>
+              <property name="text">
+               <string>Rext</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="FloatEdit" name="lf_RRext">
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Rotor external radius</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="unit_RRext">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>m</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="in_RRint">
+              <property name="minimumSize">
+               <size>
+                <width>30</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Rotor internal radius</string>
+              </property>
+              <property name="text">
+               <string>Rint</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="FloatEdit" name="lf_RRint">
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>100</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Rotor internal radius</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLabel" name="unit_RRint">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>m</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="out_airgap">
+           <property name="toolTip">
+            <string>mechanical airgap width (distance between stator bore and rotor bore radii)</string>
+           </property>
+           <property name="text">
+            <string>airgap = </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="g_shaft">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Shaft</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <widget class="WMatSelectV" name="w_mat_0" native="true">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="out_Drsh">
+              <property name="toolTip">
+               <string>Shaft Diameter</string>
+              </property>
+              <property name="text">
+               <string>Drsh = 2*Rotor.Rint</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="g_frame">
+           <property name="title">
+            <string>Frame</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="WMatSelectV" name="w_mat_1" native="true">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QGridLayout" name="gridLayout">
+              <item row="1" column="1">
+               <widget class="FloatEdit" name="lf_Lfra">
+                <property name="maximumSize">
+                 <size>
+                  <width>100</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>Frame length</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Frame length</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="in_Lfra">
+                <property name="toolTip">
+                 <string>Frame length</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Frame length</string>
+                </property>
+                <property name="text">
+                 <string>Lfra</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="FloatEdit" name="lf_Wfra">
+                <property name="maximumSize">
+                 <size>
+                  <width>100</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>Frame width</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Frame width</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="in_Wfra">
+                <property name="toolTip">
+                 <string>Frame width</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Frame width</string>
+                </property>
+                <property name="text">
+                 <string>Wfra</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="unit_Lfra">
+                <property name="toolTip">
+                 <string>Frame length</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Frame length</string>
+                </property>
+                <property name="text">
+                 <string>m</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="unit_Wfra">
+                <property name="toolTip">
+                 <string>Frame width</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Frame width</string>
+                </property>
+                <property name="text">
+                 <string>m</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>250</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>250</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QGroupBox" name="g_stator">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Stator</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <widget class="QLabel" name="in_SRext">
-           <property name="minimumSize">
-            <size>
-             <width>30</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Stator external radius</string>
-           </property>
-           <property name="text">
-            <string>Rext</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="FloatEdit" name="lf_SRext">
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Stator external radius</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="unit_SRext">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>m</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="in_SRint">
-           <property name="minimumSize">
-            <size>
-             <width>30</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Stator internal radius</string>
-           </property>
-           <property name="text">
-            <string>Rint</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="FloatEdit" name="lf_SRint">
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>100</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Stator internal radius</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QLabel" name="unit_SRint">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>m</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_rotor">
-        <property name="title">
-         <string>Rotor</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <item row="0" column="0">
-          <widget class="QLabel" name="in_RRext">
-           <property name="minimumSize">
-            <size>
-             <width>30</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Rotor external radius</string>
-           </property>
-           <property name="text">
-            <string>Rext</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="FloatEdit" name="lf_RRext">
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Rotor external radius</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="unit_RRext">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>m</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="in_RRint">
-           <property name="minimumSize">
-            <size>
-             <width>30</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Rotor internal radius</string>
-           </property>
-           <property name="text">
-            <string>Rint</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="FloatEdit" name="lf_RRint">
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>100</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Rotor internal radius</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QLabel" name="unit_RRint">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>m</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="out_airgap">
-        <property name="toolTip">
-         <string>mechanical airgap width (distance between stator bore and rotor bore radii)</string>
-        </property>
-        <property name="text">
-         <string>airgap = </string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_shaft">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Shaft</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="WMatSelectV" name="w_mat_0" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="out_Drsh">
-           <property name="toolTip">
-            <string>Shaft Diameter</string>
-           </property>
-           <property name="text">
-            <string>Drsh = 2*Rotor.Rint</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="g_frame">
-        <property name="title">
-         <string>Frame</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="WMatSelectV" name="w_mat_1" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QGridLayout" name="gridLayout">
-           <item row="1" column="1">
-            <widget class="FloatEdit" name="lf_Lfra">
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Frame length</string>
-             </property>
-             <property name="whatsThis">
-              <string>Frame length</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="in_Lfra">
-             <property name="toolTip">
-              <string>Frame length</string>
-             </property>
-             <property name="whatsThis">
-              <string>Frame length</string>
-             </property>
-             <property name="text">
-              <string>Lfra</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="FloatEdit" name="lf_Wfra">
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Frame width</string>
-             </property>
-             <property name="whatsThis">
-              <string>Frame width</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="in_Wfra">
-             <property name="toolTip">
-              <string>Frame width</string>
-             </property>
-             <property name="whatsThis">
-              <string>Frame width</string>
-             </property>
-             <property name="text">
-              <string>Wfra</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
-            <widget class="QLabel" name="unit_Lfra">
-             <property name="toolTip">
-              <string>Frame length</string>
-             </property>
-             <property name="whatsThis">
-              <string>Frame length</string>
-             </property>
-             <property name="text">
-              <string>m</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="unit_Wfra">
-             <property name="toolTip">
-              <string>Frame width</string>
-             </property>
-             <property name="whatsThis">
-              <string>Frame width</string>
-             </property>
-             <property name="text">
-              <string>m</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="b_previous">
-          <property name="text">
-           <string>Previous</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="b_next">
-          <property name="text">
-           <string>Next</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="b_previous">
+       <property name="text">
+        <string>Previous</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="b_next">
+       <property name="text">
+        <string>Next</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SMachineDimension/Ui_SMachineDimension.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SMachineDimension/Ui_SMachineDimension.py
@@ -19,9 +19,11 @@ class Ui_SMachineDimension(object):
     def setupUi(self, SMachineDimension):
         if not SMachineDimension.objectName():
             SMachineDimension.setObjectName(u"SMachineDimension")
-        SMachineDimension.resize(919, 550)
+        SMachineDimension.resize(1065, 679)
         SMachineDimension.setMinimumSize(QSize(650, 550))
-        self.horizontalLayout_2 = QHBoxLayout(SMachineDimension)
+        self.verticalLayout_3 = QVBoxLayout(SMachineDimension)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.horizontalLayout_2 = QHBoxLayout()
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
         self.img_machine = QLabel(SMachineDimension)
         self.img_machine.setObjectName(u"img_machine")
@@ -36,13 +38,17 @@ class Ui_SMachineDimension(object):
 
         self.horizontalLayout_2.addWidget(self.img_machine)
 
-        self.widget = QWidget(SMachineDimension)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_3 = QVBoxLayout(self.widget)
-        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
-        self.g_stator = QGroupBox(self.widget)
+        self.scrollArea = QScrollArea(SMachineDimension)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 616))
+        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.g_stator = QGroupBox(self.scrollAreaWidgetContents)
         self.g_stator.setObjectName(u"g_stator")
         self.g_stator.setMinimumSize(QSize(150, 0))
         self.g_stator.setMaximumSize(QSize(16777215, 16777215))
@@ -89,9 +95,9 @@ class Ui_SMachineDimension(object):
 
         self.gridLayout_2.addWidget(self.unit_SRint, 1, 2, 1, 1)
 
-        self.verticalLayout_3.addWidget(self.g_stator)
+        self.verticalLayout_4.addWidget(self.g_stator)
 
-        self.g_rotor = QGroupBox(self.widget)
+        self.g_rotor = QGroupBox(self.scrollAreaWidgetContents)
         self.g_rotor.setObjectName(u"g_rotor")
         self.gridLayout_3 = QGridLayout(self.g_rotor)
         self.gridLayout_3.setObjectName(u"gridLayout_3")
@@ -133,14 +139,14 @@ class Ui_SMachineDimension(object):
 
         self.gridLayout_3.addWidget(self.unit_RRint, 1, 2, 1, 1)
 
-        self.verticalLayout_3.addWidget(self.g_rotor)
+        self.verticalLayout_4.addWidget(self.g_rotor)
 
-        self.out_airgap = QLabel(self.widget)
+        self.out_airgap = QLabel(self.scrollAreaWidgetContents)
         self.out_airgap.setObjectName(u"out_airgap")
 
-        self.verticalLayout_3.addWidget(self.out_airgap)
+        self.verticalLayout_4.addWidget(self.out_airgap)
 
-        self.g_shaft = QGroupBox(self.widget)
+        self.g_shaft = QGroupBox(self.scrollAreaWidgetContents)
         self.g_shaft.setObjectName(u"g_shaft")
         self.g_shaft.setMinimumSize(QSize(0, 0))
         self.g_shaft.setCheckable(True)
@@ -157,9 +163,9 @@ class Ui_SMachineDimension(object):
 
         self.verticalLayout.addWidget(self.out_Drsh)
 
-        self.verticalLayout_3.addWidget(self.g_shaft)
+        self.verticalLayout_4.addWidget(self.g_shaft)
 
-        self.g_frame = QGroupBox(self.widget)
+        self.g_frame = QGroupBox(self.scrollAreaWidgetContents)
         self.g_frame.setObjectName(u"g_frame")
         self.g_frame.setCheckable(True)
         self.verticalLayout_2 = QVBoxLayout(self.g_frame)
@@ -206,13 +212,19 @@ class Ui_SMachineDimension(object):
 
         self.verticalLayout_2.addLayout(self.gridLayout)
 
-        self.verticalLayout_3.addWidget(self.g_frame)
+        self.verticalLayout_4.addWidget(self.g_frame)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout_3.addItem(self.verticalSpacer)
+        self.verticalLayout_4.addItem(self.verticalSpacer)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout_2.addWidget(self.scrollArea)
+
+        self.verticalLayout_3.addLayout(self.horizontalLayout_2)
 
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setObjectName(u"horizontalLayout")
@@ -222,19 +234,17 @@ class Ui_SMachineDimension(object):
 
         self.horizontalLayout.addItem(self.horizontalSpacer)
 
-        self.b_previous = QPushButton(self.widget)
+        self.b_previous = QPushButton(SMachineDimension)
         self.b_previous.setObjectName(u"b_previous")
 
         self.horizontalLayout.addWidget(self.b_previous)
 
-        self.b_next = QPushButton(self.widget)
+        self.b_next = QPushButton(SMachineDimension)
         self.b_next.setObjectName(u"b_next")
 
         self.horizontalLayout.addWidget(self.b_next)
 
         self.verticalLayout_3.addLayout(self.horizontalLayout)
-
-        self.horizontalLayout_2.addWidget(self.widget)
 
         self.retranslateUi(SMachineDimension)
         self.g_shaft.toggled.connect(self.out_Drsh.setVisible)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot60/PWSlot60.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot60/PWSlot60.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
-    <height>470</height>
+    <width>913</width>
+    <height>529</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -87,212 +87,252 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0">
-        <widget class="QLabel" name="in_R1">
-         <property name="text">
-          <string>R1 :</string>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="minimumSize">
+      <size>
+       <width>270</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>270</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>505</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H3">
+           <property name="text">
+            <string>d_coil_pole_top :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H3"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_H4">
+           <property name="text">
+            <string>d_coil_pole_bot :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_H4"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_H4">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>d_coil_pole_edg :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="7" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="FloatEdit" name="lf_R1"/>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="unit_R1">
-         <property name="text">
-          <string>m</string>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-        </widget>
+        </spacer>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="in_W1">
-         <property name="text">
-          <string>W1 :</string>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
          </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="FloatEdit" name="lf_W1"/>
-       </item>
-       <item row="1" column="2">
-        <widget class="QLabel" name="unit_W1">
-         <property name="text">
-          <string>m</string>
+         <property name="title">
+          <string>Output</string>
          </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="in_W2">
-         <property name="text">
-          <string>W2 :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="FloatEdit" name="lf_W2"/>
-       </item>
-       <item row="2" column="2">
-        <widget class="QLabel" name="unit_W2">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="in_H1">
-         <property name="text">
-          <string>H1 :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="FloatEdit" name="lf_H1"/>
-       </item>
-       <item row="3" column="2">
-        <widget class="QLabel" name="unit_H1">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="in_H2">
-         <property name="text">
-          <string>H2 :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="FloatEdit" name="lf_H2"/>
-       </item>
-       <item row="4" column="2">
-        <widget class="QLabel" name="unit_H2">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="in_H3">
-         <property name="text">
-          <string>d_coil_pole_top :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="FloatEdit" name="lf_H3"/>
-       </item>
-       <item row="5" column="2">
-        <widget class="QLabel" name="unit_H3">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="in_H4">
-         <property name="text">
-          <string>d_coil_pole_bot :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="FloatEdit" name="lf_H4"/>
-       </item>
-       <item row="6" column="2">
-        <widget class="QLabel" name="unit_H4">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="in_W3">
-         <property name="text">
-          <string>d_coil_pole_edg :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="FloatEdit" name="lf_W3"/>
-       </item>
-       <item row="7" column="2">
-        <widget class="QLabel" name="unit_W3">
-         <property name="text">
-          <string>m</string>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QLabel" name="out_Wlam">
+            <property name="text">
+             <string>Lamination width : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_slot_height">
+            <property name="text">
+             <string>Slot height : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_yoke_height">
+            <property name="text">
+             <string>Yoke height : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_wind_surface">
+            <property name="text">
+             <string>Winding surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_tot_surface">
+            <property name="text">
+             <string>Total surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_op_angle">
+            <property name="text">
+             <string>Opening angle : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_tooth_width">
+            <property name="text">
+             <string>Tooth average width : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="g_output">
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="title">
-        <string>Output</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <item>
-         <widget class="QLabel" name="out_Wlam">
-          <property name="text">
-           <string>Lamination width : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_slot_height">
-          <property name="text">
-           <string>Slot height : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_yoke_height">
-          <property name="text">
-           <string>Yoke height : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_wind_surface">
-          <property name="text">
-           <string>Winding surface : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_tot_surface">
-          <property name="text">
-           <string>Total surface : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_op_angle">
-          <property name="text">
-           <string>Opening angle : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_tooth_width">
-          <property name="text">
-           <string>Tooth average width : ?</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot60/Ui_PWSlot60.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot60/Ui_PWSlot60.py
@@ -18,7 +18,7 @@ class Ui_PWSlot60(object):
     def setupUi(self, PWSlot60):
         if not PWSlot60.objectName():
             PWSlot60.setObjectName(u"PWSlot60")
-        PWSlot60.resize(630, 470)
+        PWSlot60.resize(913, 529)
         PWSlot60.setMinimumSize(QSize(630, 470))
         PWSlot60.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot60)
@@ -59,133 +59,147 @@ class Ui_PWSlot60(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.verticalLayout = QVBoxLayout()
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PWSlot60)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents_2 = QWidget()
+        self.scrollAreaWidgetContents_2.setObjectName(u"scrollAreaWidgetContents_2")
+        self.scrollAreaWidgetContents_2.setGeometry(QRect(0, 0, 268, 505))
+        self.verticalLayout_4 = QVBoxLayout(self.scrollAreaWidgetContents_2)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_R1 = QLabel(PWSlot60)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 0, 0, 1, 1)
 
-        self.lf_R1 = FloatEdit(PWSlot60)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 0, 1, 1, 1)
 
-        self.unit_R1 = QLabel(PWSlot60)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(PWSlot60)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(PWSlot60)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(PWSlot60)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(PWSlot60)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(PWSlot60)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(PWSlot60)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_H1 = QLabel(PWSlot60)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 3, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(PWSlot60)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 3, 1, 1, 1)
 
-        self.unit_H1 = QLabel(PWSlot60)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 3, 2, 1, 1)
 
-        self.in_H2 = QLabel(PWSlot60)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 4, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(PWSlot60)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 4, 1, 1, 1)
 
-        self.unit_H2 = QLabel(PWSlot60)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 4, 2, 1, 1)
 
-        self.in_H3 = QLabel(PWSlot60)
+        self.in_H3 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_H3.setObjectName(u"in_H3")
 
         self.gridLayout.addWidget(self.in_H3, 5, 0, 1, 1)
 
-        self.lf_H3 = FloatEdit(PWSlot60)
+        self.lf_H3 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_H3.setObjectName(u"lf_H3")
 
         self.gridLayout.addWidget(self.lf_H3, 5, 1, 1, 1)
 
-        self.unit_H3 = QLabel(PWSlot60)
+        self.unit_H3 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_H3.setObjectName(u"unit_H3")
 
         self.gridLayout.addWidget(self.unit_H3, 5, 2, 1, 1)
 
-        self.in_H4 = QLabel(PWSlot60)
+        self.in_H4 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_H4.setObjectName(u"in_H4")
 
         self.gridLayout.addWidget(self.in_H4, 6, 0, 1, 1)
 
-        self.lf_H4 = FloatEdit(PWSlot60)
+        self.lf_H4 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_H4.setObjectName(u"lf_H4")
 
         self.gridLayout.addWidget(self.lf_H4, 6, 1, 1, 1)
 
-        self.unit_H4 = QLabel(PWSlot60)
+        self.unit_H4 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_H4.setObjectName(u"unit_H4")
 
         self.gridLayout.addWidget(self.unit_H4, 6, 2, 1, 1)
 
-        self.in_W3 = QLabel(PWSlot60)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents_2)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 7, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(PWSlot60)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents_2)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 7, 1, 1, 1)
 
-        self.unit_W3 = QLabel(PWSlot60)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents_2)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 7, 2, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_4.addLayout(self.gridLayout)
 
-        self.g_output = QGroupBox(PWSlot60)
+        self.verticalSpacer = QSpacerItem(
+            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
+
+        self.verticalLayout_4.addItem(self.verticalSpacer)
+
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents_2)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout_3 = QVBoxLayout(self.g_output)
@@ -225,9 +239,11 @@ class Ui_PWSlot60(object):
 
         self.verticalLayout_3.addWidget(self.out_tooth_width)
 
-        self.verticalLayout.addWidget(self.g_output)
+        self.verticalLayout_4.addWidget(self.g_output)
 
-        self.horizontalLayout.addLayout(self.verticalLayout)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents_2)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_R1, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot61/PWSlot61.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot61/PWSlot61.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
-    <height>470</height>
+    <width>936</width>
+    <height>532</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -86,229 +86,269 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0">
-        <widget class="QLabel" name="in_W0">
-         <property name="text">
-          <string>W0 :</string>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="minimumSize">
+      <size>
+       <width>270</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>270</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>508</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2 :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_H3">
+           <property name="text">
+            <string>d_coil_pole_top :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_H3"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_H3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="in_H4">
+           <property name="text">
+            <string>d_coil_pole_bot :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="FloatEdit" name="lf_H4"/>
+         </item>
+         <item row="7" column="2">
+          <widget class="QLabel" name="unit_H4">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>d_coil_pole_edg :</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="8" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="FloatEdit" name="lf_W0"/>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="unit_W0">
-         <property name="text">
-          <string>m</string>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-        </widget>
+        </spacer>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="in_W1">
-         <property name="text">
-          <string>W1 :</string>
+       <item>
+        <widget class="QGroupBox" name="g_output">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
          </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="FloatEdit" name="lf_W1"/>
-       </item>
-       <item row="1" column="2">
-        <widget class="QLabel" name="unit_W1">
-         <property name="text">
-          <string>m</string>
+         <property name="title">
+          <string>Output</string>
          </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="in_W2">
-         <property name="text">
-          <string>W2 :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="FloatEdit" name="lf_W2"/>
-       </item>
-       <item row="2" column="2">
-        <widget class="QLabel" name="unit_W2">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="in_H0">
-         <property name="text">
-          <string>H0 :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="FloatEdit" name="lf_H0"/>
-       </item>
-       <item row="3" column="2">
-        <widget class="QLabel" name="unit_H0">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="in_H1">
-         <property name="text">
-          <string>H1 :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="FloatEdit" name="lf_H1"/>
-       </item>
-       <item row="4" column="2">
-        <widget class="QLabel" name="unit_H1">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="in_H2">
-         <property name="text">
-          <string>H2 :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="FloatEdit" name="lf_H2"/>
-       </item>
-       <item row="5" column="2">
-        <widget class="QLabel" name="unit_H2">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="in_H3">
-         <property name="text">
-          <string>d_coil_pole_top :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="FloatEdit" name="lf_H3"/>
-       </item>
-       <item row="6" column="2">
-        <widget class="QLabel" name="unit_H3">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="in_H4">
-         <property name="text">
-          <string>d_coil_pole_bot :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="FloatEdit" name="lf_H4"/>
-       </item>
-       <item row="7" column="2">
-        <widget class="QLabel" name="unit_H4">
-         <property name="text">
-          <string>m</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="in_W3">
-         <property name="text">
-          <string>d_coil_pole_edg :</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="FloatEdit" name="lf_W3"/>
-       </item>
-       <item row="8" column="2">
-        <widget class="QLabel" name="unit_W3">
-         <property name="text">
-          <string>m</string>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QLabel" name="out_Wlam">
+            <property name="text">
+             <string>Lamination width : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_slot_height">
+            <property name="text">
+             <string>Slot height : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_yoke_height">
+            <property name="text">
+             <string>Yoke height : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_wind_surface">
+            <property name="text">
+             <string>Winding surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_tot_surface">
+            <property name="text">
+             <string>Total surface : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_op_angle">
+            <property name="text">
+             <string>Opening angle : ?</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="out_tooth_width">
+            <property name="text">
+             <string>Tooth average width : ?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="g_output">
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="title">
-        <string>Output</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <item>
-         <widget class="QLabel" name="out_Wlam">
-          <property name="text">
-           <string>Lamination width : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_slot_height">
-          <property name="text">
-           <string>Slot height : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_yoke_height">
-          <property name="text">
-           <string>Yoke height : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_wind_surface">
-          <property name="text">
-           <string>Winding surface : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_tot_surface">
-          <property name="text">
-           <string>Total surface : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_op_angle">
-          <property name="text">
-           <string>Opening angle : ?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="out_tooth_width">
-          <property name="text">
-           <string>Tooth average width : ?</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot61/Ui_PWSlot61.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWPole/PWSlot61/Ui_PWSlot61.py
@@ -18,7 +18,7 @@ class Ui_PWSlot61(object):
     def setupUi(self, PWSlot61):
         if not PWSlot61.objectName():
             PWSlot61.setObjectName(u"PWSlot61")
-        PWSlot61.resize(630, 470)
+        PWSlot61.resize(936, 532)
         PWSlot61.setMinimumSize(QSize(630, 470))
         PWSlot61.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot61)
@@ -59,148 +59,162 @@ class Ui_PWSlot61(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.verticalLayout = QVBoxLayout()
+        self.scrollArea = QScrollArea(PWSlot61)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 508))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(PWSlot61)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(PWSlot61)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(PWSlot61)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(PWSlot61)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(PWSlot61)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(PWSlot61)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(PWSlot61)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(PWSlot61)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(PWSlot61)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(PWSlot61)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(PWSlot61)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 3, 1, 1, 1)
 
-        self.unit_H0 = QLabel(PWSlot61)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 3, 2, 1, 1)
 
-        self.in_H1 = QLabel(PWSlot61)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 4, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(PWSlot61)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 4, 1, 1, 1)
 
-        self.unit_H1 = QLabel(PWSlot61)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 4, 2, 1, 1)
 
-        self.in_H2 = QLabel(PWSlot61)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 5, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(PWSlot61)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 5, 1, 1, 1)
 
-        self.unit_H2 = QLabel(PWSlot61)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 5, 2, 1, 1)
 
-        self.in_H3 = QLabel(PWSlot61)
+        self.in_H3 = QLabel(self.scrollAreaWidgetContents)
         self.in_H3.setObjectName(u"in_H3")
 
         self.gridLayout.addWidget(self.in_H3, 6, 0, 1, 1)
 
-        self.lf_H3 = FloatEdit(PWSlot61)
+        self.lf_H3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H3.setObjectName(u"lf_H3")
 
         self.gridLayout.addWidget(self.lf_H3, 6, 1, 1, 1)
 
-        self.unit_H3 = QLabel(PWSlot61)
+        self.unit_H3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H3.setObjectName(u"unit_H3")
 
         self.gridLayout.addWidget(self.unit_H3, 6, 2, 1, 1)
 
-        self.in_H4 = QLabel(PWSlot61)
+        self.in_H4 = QLabel(self.scrollAreaWidgetContents)
         self.in_H4.setObjectName(u"in_H4")
 
         self.gridLayout.addWidget(self.in_H4, 7, 0, 1, 1)
 
-        self.lf_H4 = FloatEdit(PWSlot61)
+        self.lf_H4 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H4.setObjectName(u"lf_H4")
 
         self.gridLayout.addWidget(self.lf_H4, 7, 1, 1, 1)
 
-        self.unit_H4 = QLabel(PWSlot61)
+        self.unit_H4 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H4.setObjectName(u"unit_H4")
 
         self.gridLayout.addWidget(self.unit_H4, 7, 2, 1, 1)
 
-        self.in_W3 = QLabel(PWSlot61)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 8, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(PWSlot61)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 8, 1, 1, 1)
 
-        self.unit_W3 = QLabel(PWSlot61)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 8, 2, 1, 1)
 
         self.verticalLayout.addLayout(self.gridLayout)
 
-        self.g_output = QGroupBox(PWSlot61)
+        self.verticalSpacer = QSpacerItem(
+            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
+
+        self.verticalLayout.addItem(self.verticalSpacer)
+
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout_3 = QVBoxLayout(self.g_output)
@@ -242,7 +256,9 @@ class Ui_PWSlot61(object):
 
         self.verticalLayout.addWidget(self.g_output)
 
-        self.horizontalLayout.addLayout(self.verticalLayout)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot10/PWSlot10.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot10/PWSlot10.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>1082</width>
     <height>470</height>
    </rect>
   </property>
@@ -87,155 +87,168 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QComboBox" name="c_H1_unit">
-          <item>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
            <property name="text">
-            <string>[m]</string>
+            <string>W0</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
            <property name="text">
-            <string>[rad]</string>
+            <string>m</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
            <property name="text">
-            <string>[deg]</string>
+            <string>W1</string>
            </property>
-          </item>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QComboBox" name="c_H1_unit">
+           <item>
+            <property name="text">
+             <string>[m]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[rad]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[deg]</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot10/Ui_PWSlot10.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot10/Ui_PWSlot10.py
@@ -19,7 +19,7 @@ class Ui_PWSlot10(object):
     def setupUi(self, PWSlot10):
         if not PWSlot10.objectName():
             PWSlot10.setObjectName(u"PWSlot10")
-        PWSlot10.resize(630, 470)
+        PWSlot10.resize(1082, 470)
         PWSlot10.setMinimumSize(QSize(630, 470))
         PWSlot10.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot10)
@@ -60,60 +60,64 @@ class Ui_PWSlot10(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot10)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot10)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 3, 0, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 3, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 4, 0, 1, 1)
 
-        self.c_H1_unit = QComboBox(self.widget)
+        self.c_H1_unit = QComboBox(self.scrollAreaWidgetContents)
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
@@ -121,42 +125,42 @@ class Ui_PWSlot10(object):
 
         self.gridLayout.addWidget(self.c_H1_unit, 4, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 5, 0, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 5, 2, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 3, 1, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 4, 1, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 5, 1, 1, 1)
@@ -169,12 +173,14 @@ class Ui_PWSlot10(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot11/PWSlot11.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot11/PWSlot11.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>937</width>
+    <width>1282</width>
     <height>470</height>
    </rect>
   </property>
@@ -88,172 +88,185 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QComboBox" name="c_H1_unit">
-          <item>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
            <property name="text">
-            <string>[m]</string>
+            <string>W0</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
            <property name="text">
-            <string>[rad]</string>
+            <string>m</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
            <property name="text">
-            <string>[deg]</string>
+            <string>W1</string>
            </property>
-          </item>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_R1">
-          <property name="text">
-           <string>R1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_R1"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_R1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QComboBox" name="c_H1_unit">
+           <item>
+            <property name="text">
+             <string>[m]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[rad]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[deg]</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot11/Ui_PWSlot11.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot11/Ui_PWSlot11.py
@@ -19,7 +19,7 @@ class Ui_PWSlot11(object):
     def setupUi(self, PWSlot11):
         if not PWSlot11.objectName():
             PWSlot11.setObjectName(u"PWSlot11")
-        PWSlot11.resize(937, 470)
+        PWSlot11.resize(1282, 470)
         PWSlot11.setMinimumSize(QSize(630, 470))
         PWSlot11.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot11)
@@ -60,85 +60,89 @@ class Ui_PWSlot11(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot11)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PWSlot11)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 3, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 3, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 4, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 4, 1, 1, 1)
 
-        self.c_H1_unit = QComboBox(self.widget)
+        self.c_H1_unit = QComboBox(self.scrollAreaWidgetContents)
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
@@ -146,50 +150,52 @@ class Ui_PWSlot11(object):
 
         self.gridLayout.addWidget(self.c_H1_unit, 4, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 5, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 5, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 5, 2, 1, 1)
 
-        self.in_R1 = QLabel(self.widget)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 6, 0, 1, 1)
 
-        self.lf_R1 = FloatEdit(self.widget)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 6, 1, 1, 1)
 
-        self.unit_R1 = QLabel(self.widget)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 6, 2, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_3.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_3.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot12/PWSlot12.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot12/PWSlot12.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>812</width>
-    <height>470</height>
+    <width>964</width>
+    <height>503</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -56,109 +56,122 @@
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_R1">
-          <property name="text">
-           <string>R1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_R1"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_R1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_R2">
-          <property name="text">
-           <string>R2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_R2"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_R2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>479</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_R2">
+           <property name="text">
+            <string>R2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_R2"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_R2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot12/Ui_PWSlot12.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot12/Ui_PWSlot12.py
@@ -19,7 +19,7 @@ class Ui_PWSlot12(object):
     def setupUi(self, PWSlot12):
         if not PWSlot12.objectName():
             PWSlot12.setObjectName(u"PWSlot12")
-        PWSlot12.resize(812, 470)
+        PWSlot12.resize(964, 503)
         PWSlot12.setMinimumSize(QSize(630, 470))
         PWSlot12.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot12)
@@ -43,88 +43,94 @@ class Ui_PWSlot12(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot12)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PWSlot12)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 479))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_R1 = QLabel(self.widget)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 0, 0, 1, 1)
 
-        self.lf_R1 = FloatEdit(self.widget)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 0, 1, 1, 1)
 
-        self.unit_R1 = QLabel(self.widget)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 0, 2, 1, 1)
 
-        self.in_R2 = QLabel(self.widget)
+        self.in_R2 = QLabel(self.scrollAreaWidgetContents)
         self.in_R2.setObjectName(u"in_R2")
 
         self.gridLayout.addWidget(self.in_R2, 1, 0, 1, 1)
 
-        self.lf_R2 = FloatEdit(self.widget)
+        self.lf_R2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R2.setObjectName(u"lf_R2")
 
         self.gridLayout.addWidget(self.lf_R2, 1, 1, 1, 1)
 
-        self.unit_R2 = QLabel(self.widget)
+        self.unit_R2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R2.setObjectName(u"unit_R2")
 
         self.gridLayout.addWidget(self.unit_R2, 1, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 3, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 3, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 3, 2, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_3.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_3.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_R1, self.lf_R2)
         QWidget.setTabOrder(self.lf_R2, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot13/PWSlot13.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot13/PWSlot13.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>797</width>
+    <width>838</width>
     <height>470</height>
    </rect>
   </property>
@@ -87,172 +87,185 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QComboBox" name="c_H1_unit">
-          <item>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
            <property name="text">
-            <string>[m]</string>
+            <string>W0</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
            <property name="text">
-            <string>[rad]</string>
+            <string>m</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
            <property name="text">
-            <string>[deg]</string>
+            <string>W1</string>
            </property>
-          </item>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QComboBox" name="c_H1_unit">
+           <item>
+            <property name="text">
+             <string>[m]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[rad]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[deg]</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot13/Ui_PWSlot13.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot13/Ui_PWSlot13.py
@@ -19,7 +19,7 @@ class Ui_PWSlot13(object):
     def setupUi(self, PWSlot13):
         if not PWSlot13.objectName():
             PWSlot13.setObjectName(u"PWSlot13")
-        PWSlot13.resize(797, 470)
+        PWSlot13.resize(838, 470)
         PWSlot13.setMinimumSize(QSize(630, 470))
         PWSlot13.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot13)
@@ -60,100 +60,104 @@ class Ui_PWSlot13(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot13)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot13)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 3, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 3, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 3, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 4, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 4, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 4, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 5, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 5, 1, 1, 1)
 
-        self.c_H1_unit = QComboBox(self.widget)
+        self.c_H1_unit = QComboBox(self.scrollAreaWidgetContents)
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
@@ -161,17 +165,17 @@ class Ui_PWSlot13(object):
 
         self.gridLayout.addWidget(self.c_H1_unit, 5, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 6, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 6, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 6, 2, 1, 1)
@@ -184,12 +188,14 @@ class Ui_PWSlot13(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot14/PWSlot14.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot14/PWSlot14.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>903</width>
+    <width>885</width>
     <height>470</height>
    </rect>
   </property>
@@ -56,126 +56,139 @@
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H3">
-          <property name="text">
-           <string>H3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H3"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_H3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H3">
+           <property name="text">
+            <string>H3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H3"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot14/Ui_PWSlot14.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot14/Ui_PWSlot14.py
@@ -19,7 +19,7 @@ class Ui_PWSlot14(object):
     def setupUi(self, PWSlot14):
         if not PWSlot14.objectName():
             PWSlot14.setObjectName(u"PWSlot14")
-        PWSlot14.resize(903, 470)
+        PWSlot14.resize(885, 470)
         PWSlot14.setMinimumSize(QSize(630, 470))
         PWSlot14.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot14)
@@ -43,85 +43,89 @@ class Ui_PWSlot14(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot14)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot14)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 1, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 1, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 1, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 3, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 3, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 3, 2, 1, 1)
 
-        self.in_H3 = QLabel(self.widget)
+        self.in_H3 = QLabel(self.scrollAreaWidgetContents)
         self.in_H3.setObjectName(u"in_H3")
 
         self.gridLayout.addWidget(self.in_H3, 4, 0, 1, 1)
 
-        self.lf_H3 = FloatEdit(self.widget)
+        self.lf_H3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H3.setObjectName(u"lf_H3")
 
         self.gridLayout.addWidget(self.lf_H3, 4, 1, 1, 1)
 
-        self.unit_H3 = QLabel(self.widget)
+        self.unit_H3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H3.setObjectName(u"unit_H3")
 
         self.gridLayout.addWidget(self.unit_H3, 4, 2, 1, 1)
@@ -134,12 +138,14 @@ class Ui_PWSlot14(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W3)
         QWidget.setTabOrder(self.lf_W3, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot15/PWSlot15.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot15/PWSlot15.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>766</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,160 +86,173 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_R1">
-          <property name="text">
-           <string>R1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_R1"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_R1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_R2">
-          <property name="text">
-           <string>R2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_R2"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_R2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_R2">
+           <property name="text">
+            <string>R2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_R2"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_R2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot15/Ui_PWSlot15.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot15/Ui_PWSlot15.py
@@ -19,7 +19,7 @@ class Ui_PWSlot15(object):
     def setupUi(self, PWSlot15):
         if not PWSlot15.objectName():
             PWSlot15.setObjectName(u"PWSlot15")
-        PWSlot15.resize(630, 470)
+        PWSlot15.resize(766, 470)
         PWSlot15.setMinimumSize(QSize(630, 470))
         PWSlot15.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot15)
@@ -60,115 +60,119 @@ class Ui_PWSlot15(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot15)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot15)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 1, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 1, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 1, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 3, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 3, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 3, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 4, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 4, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 4, 2, 1, 1)
 
-        self.in_R1 = QLabel(self.widget)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 5, 0, 1, 1)
 
-        self.lf_R1 = FloatEdit(self.widget)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 5, 1, 1, 1)
 
-        self.unit_R1 = QLabel(self.widget)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 5, 2, 1, 1)
 
-        self.in_R2 = QLabel(self.widget)
+        self.in_R2 = QLabel(self.scrollAreaWidgetContents)
         self.in_R2.setObjectName(u"in_R2")
 
         self.gridLayout.addWidget(self.in_R2, 6, 0, 1, 1)
 
-        self.lf_R2 = FloatEdit(self.widget)
+        self.lf_R2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R2.setObjectName(u"lf_R2")
 
         self.gridLayout.addWidget(self.lf_R2, 6, 1, 1, 1)
 
-        self.unit_R2 = QLabel(self.widget)
+        self.unit_R2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R2.setObjectName(u"unit_R2")
 
         self.gridLayout.addWidget(self.unit_R2, 6, 2, 1, 1)
@@ -181,12 +185,14 @@ class Ui_PWSlot15(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W3)
         QWidget.setTabOrder(self.lf_W3, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot16/PWSlot16.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot16/PWSlot16.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>822</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,126 +86,139 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>[rad]</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_R1">
-          <property name="text">
-           <string>R1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_R1"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_R1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>[rad]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot16/Ui_PWSlot16.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot16/Ui_PWSlot16.py
@@ -19,7 +19,7 @@ class Ui_PWSlot16(object):
     def setupUi(self, PWSlot16):
         if not PWSlot16.objectName():
             PWSlot16.setObjectName(u"PWSlot16")
-        PWSlot16.resize(630, 470)
+        PWSlot16.resize(822, 470)
         PWSlot16.setMinimumSize(QSize(630, 470))
         PWSlot16.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot16)
@@ -60,85 +60,89 @@ class Ui_PWSlot16(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot16)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot16)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 1, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 1, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 1, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 3, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 3, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 3, 2, 1, 1)
 
-        self.in_R1 = QLabel(self.widget)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 4, 0, 1, 1)
 
-        self.lf_R1 = FloatEdit(self.widget)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 4, 1, 1, 1)
 
-        self.unit_R1 = QLabel(self.widget)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 4, 2, 1, 1)
@@ -151,12 +155,14 @@ class Ui_PWSlot16(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W3)
         QWidget.setTabOrder(self.lf_W3, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot21/PWSlot21.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot21/PWSlot21.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>797</width>
     <height>470</height>
    </rect>
   </property>
@@ -87,155 +87,168 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QComboBox" name="c_H1_unit">
-          <item>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
            <property name="text">
-            <string>[m]</string>
+            <string>W0</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
            <property name="text">
-            <string>[rad]</string>
+            <string>m</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
            <property name="text">
-            <string>[deg]</string>
+            <string>W1</string>
            </property>
-          </item>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QComboBox" name="c_H1_unit">
+           <item>
+            <property name="text">
+             <string>[m]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[rad]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[deg]</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot21/Ui_PWSlot21.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot21/Ui_PWSlot21.py
@@ -19,7 +19,7 @@ class Ui_PWSlot21(object):
     def setupUi(self, PWSlot21):
         if not PWSlot21.objectName():
             PWSlot21.setObjectName(u"PWSlot21")
-        PWSlot21.resize(630, 470)
+        PWSlot21.resize(797, 470)
         PWSlot21.setMinimumSize(QSize(630, 470))
         PWSlot21.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot21)
@@ -60,85 +60,89 @@ class Ui_PWSlot21(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot21)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot21)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 3, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 3, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 4, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 4, 1, 1, 1)
 
-        self.c_H1_unit = QComboBox(self.widget)
+        self.c_H1_unit = QComboBox(self.scrollAreaWidgetContents)
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
         self.c_H1_unit.addItem("")
@@ -146,17 +150,17 @@ class Ui_PWSlot21(object):
 
         self.gridLayout.addWidget(self.c_H1_unit, 4, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 5, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 5, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 5, 2, 1, 1)
@@ -169,12 +173,14 @@ class Ui_PWSlot21(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot22/PWSlot22.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot22/PWSlot22.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>665</width>
+    <width>641</width>
     <height>470</height>
    </rect>
   </property>
@@ -87,135 +87,148 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QComboBox" name="c_W2_unit">
-          <property name="maximumSize">
-           <size>
-            <width>70</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <item>
-           <property name="text">
-            <string>[rad]</string>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QComboBox" name="c_W2_unit">
+           <property name="maximumSize">
+            <size>
+             <width>70</width>
+             <height>16777215</height>
+            </size>
            </property>
-          </item>
-          <item>
+           <item>
+            <property name="text">
+             <string>[rad]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[deg]</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
            <property name="text">
-            <string>[deg]</string>
+            <string>H0</string>
            </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QComboBox" name="c_W0_unit">
-          <property name="maximumSize">
-           <size>
-            <width>70</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <item>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
            <property name="text">
-            <string>[rad]</string>
+            <string>W0</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H2">
            <property name="text">
-            <string>[deg]</string>
+            <string>H2</string>
            </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QComboBox" name="c_W0_unit">
+           <property name="maximumSize">
+            <size>
+             <width>70</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <item>
+            <property name="text">
+             <string>[rad]</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[deg]</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot22/Ui_PWSlot22.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot22/Ui_PWSlot22.py
@@ -19,7 +19,7 @@ class Ui_PWSlot22(object):
     def setupUi(self, PWSlot22):
         if not PWSlot22.objectName():
             PWSlot22.setObjectName(u"PWSlot22")
-        PWSlot22.resize(665, 470)
+        PWSlot22.resize(641, 470)
         PWSlot22.setMinimumSize(QSize(630, 470))
         PWSlot22.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot22)
@@ -60,20 +60,24 @@ class Ui_PWSlot22(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot22)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot22)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.c_W2_unit = QComboBox(self.widget)
+        self.c_W2_unit = QComboBox(self.scrollAreaWidgetContents)
         self.c_W2_unit.addItem("")
         self.c_W2_unit.addItem("")
         self.c_W2_unit.setObjectName(u"c_W2_unit")
@@ -81,47 +85,47 @@ class Ui_PWSlot22(object):
 
         self.gridLayout.addWidget(self.c_W2_unit, 1, 2, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 3, 1, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 3, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 1, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 1, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.c_W0_unit = QComboBox(self.widget)
+        self.c_W0_unit = QComboBox(self.scrollAreaWidgetContents)
         self.c_W0_unit.addItem("")
         self.c_W0_unit.addItem("")
         self.c_W0_unit.setObjectName(u"c_W0_unit")
@@ -129,7 +133,7 @@ class Ui_PWSlot22(object):
 
         self.gridLayout.addWidget(self.c_W0_unit, 0, 2, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 3, 2, 1, 1)
@@ -142,12 +146,14 @@ class Ui_PWSlot22(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W2)
         QWidget.setTabOrder(self.lf_W2, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot23/PWSlot23.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot23/PWSlot23.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>848</width>
+    <width>787</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,167 +86,180 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="is_cst_tooth">
-        <property name="text">
-         <string>Constant Tooth Width</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QCheckBox" name="is_cst_tooth">
+         <property name="text">
+          <string>Constant Tooth Width</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -265,7 +278,6 @@ p, li { white-space: pre-wrap; }
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>is_cst_tooth</tabstop>
   <tabstop>lf_W0</tabstop>
   <tabstop>lf_W1</tabstop>
   <tabstop>lf_W2</tabstop>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot23/Ui_PWSlot23.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot23/Ui_PWSlot23.py
@@ -19,7 +19,7 @@ class Ui_PWSlot23(object):
     def setupUi(self, PWSlot23):
         if not PWSlot23.objectName():
             PWSlot23.setObjectName(u"PWSlot23")
-        PWSlot23.resize(848, 470)
+        PWSlot23.resize(787, 470)
         PWSlot23.setMinimumSize(QSize(630, 470))
         PWSlot23.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot23)
@@ -60,120 +60,124 @@ class Ui_PWSlot23(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot23)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot23)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.is_cst_tooth = QCheckBox(self.widget)
+        self.is_cst_tooth = QCheckBox(self.scrollAreaWidgetContents)
         self.is_cst_tooth.setObjectName(u"is_cst_tooth")
 
         self.verticalLayout.addWidget(self.is_cst_tooth)
 
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 3, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 3, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 3, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 4, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 4, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 4, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 5, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 5, 1, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 6, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 6, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 6, 2, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 5, 2, 1, 1)
@@ -186,14 +190,15 @@ class Ui_PWSlot23(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
 
-        QWidget.setTabOrder(self.is_cst_tooth, self.lf_W0)
+        self.horizontalLayout.addWidget(self.scrollArea)
+
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)
         QWidget.setTabOrder(self.lf_W2, self.lf_W3)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot24/PWSlot24.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot24/PWSlot24.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>792</width>
     <height>470</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>630</width>
+    <width>270</width>
     <height>470</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>16777215</width>
+    <width>1101</width>
     <height>16777215</height>
    </size>
   </property>
@@ -80,75 +80,88 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot24/Ui_PWSlot24.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot24/Ui_PWSlot24.py
@@ -19,9 +19,9 @@ class Ui_PWSlot24(object):
     def setupUi(self, PWSlot24):
         if not PWSlot24.objectName():
             PWSlot24.setObjectName(u"PWSlot24")
-        PWSlot24.resize(630, 470)
-        PWSlot24.setMinimumSize(QSize(630, 470))
-        PWSlot24.setMaximumSize(QSize(16777215, 16777215))
+        PWSlot24.resize(792, 470)
+        PWSlot24.setMinimumSize(QSize(270, 470))
+        PWSlot24.setMaximumSize(QSize(1101, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot24)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.verticalLayout_2 = QVBoxLayout()
@@ -54,40 +54,44 @@ class Ui_PWSlot24(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot24)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot24)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 0, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 0, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 0, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 1, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 1, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 1, 2, 1, 1)
@@ -100,12 +104,14 @@ class Ui_PWSlot24(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         self.retranslateUi(PWSlot24)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot25/PWSlot25.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot25/PWSlot25.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>728</width>
+    <width>928</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,109 +86,122 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W4">
-          <property name="text">
-           <string>W4</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W4"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W4">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W4">
+           <property name="text">
+            <string>W4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W4"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W4">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot25/Ui_PWSlot25.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot25/Ui_PWSlot25.py
@@ -19,7 +19,7 @@ class Ui_PWSlot25(object):
     def setupUi(self, PWSlot25):
         if not PWSlot25.objectName():
             PWSlot25.setObjectName(u"PWSlot25")
-        PWSlot25.resize(728, 470)
+        PWSlot25.resize(928, 470)
         PWSlot25.setMinimumSize(QSize(630, 470))
         PWSlot25.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot25)
@@ -55,70 +55,74 @@ class Ui_PWSlot25(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot25)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot25)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 0, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 0, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 0, 2, 1, 1)
 
-        self.in_W4 = QLabel(self.widget)
+        self.in_W4 = QLabel(self.scrollAreaWidgetContents)
         self.in_W4.setObjectName(u"in_W4")
 
         self.gridLayout.addWidget(self.in_W4, 1, 0, 1, 1)
 
-        self.lf_W4 = FloatEdit(self.widget)
+        self.lf_W4 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W4.setObjectName(u"lf_W4")
 
         self.gridLayout.addWidget(self.lf_W4, 1, 1, 1, 1)
 
-        self.unit_W4 = QLabel(self.widget)
+        self.unit_W4 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W4.setObjectName(u"unit_W4")
 
         self.gridLayout.addWidget(self.unit_W4, 1, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 2, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 2, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 2, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 3, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 3, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 3, 2, 1, 1)
@@ -131,12 +135,14 @@ class Ui_PWSlot25(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         self.retranslateUi(PWSlot25)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot26/PWSlot26.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot26/PWSlot26.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>819</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,130 +86,143 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_R1">
-          <property name="text">
-           <string>R1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_R1"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_R1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_R2">
-          <property name="text">
-           <string>R2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_R2">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_R2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_R2">
+           <property name="text">
+            <string>R2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_R2">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_R2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot26/Ui_PWSlot26.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot26/Ui_PWSlot26.py
@@ -19,7 +19,7 @@ class Ui_PWSlot26(object):
     def setupUi(self, PWSlot26):
         if not PWSlot26.objectName():
             PWSlot26.setObjectName(u"PWSlot26")
-        PWSlot26.resize(630, 470)
+        PWSlot26.resize(819, 470)
         PWSlot26.setMinimumSize(QSize(630, 470))
         PWSlot26.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot26)
@@ -60,85 +60,89 @@ class Ui_PWSlot26(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot26)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot26)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 1, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 1, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 1, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 2, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 2, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 2, 2, 1, 1)
 
-        self.in_R1 = QLabel(self.widget)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 3, 0, 1, 1)
 
-        self.lf_R1 = FloatEdit(self.widget)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 3, 1, 1, 1)
 
-        self.unit_R1 = QLabel(self.widget)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 3, 2, 1, 1)
 
-        self.in_R2 = QLabel(self.widget)
+        self.in_R2 = QLabel(self.scrollAreaWidgetContents)
         self.in_R2.setObjectName(u"in_R2")
 
         self.gridLayout.addWidget(self.in_R2, 4, 0, 1, 1)
 
-        self.lf_R2 = FloatEdit(self.widget)
+        self.lf_R2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R2.setObjectName(u"lf_R2")
 
         self.gridLayout.addWidget(self.lf_R2, 4, 1, 1, 1)
 
-        self.unit_R2 = QLabel(self.widget)
+        self.unit_R2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R2.setObjectName(u"unit_R2")
 
         self.gridLayout.addWidget(self.unit_R2, 4, 2, 1, 1)
@@ -151,12 +155,14 @@ class Ui_PWSlot26(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_H0)
         QWidget.setTabOrder(self.lf_H0, self.lf_H1)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot27/PWSlot27.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot27/PWSlot27.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>657</width>
+    <width>765</width>
     <height>470</height>
    </rect>
   </property>
@@ -87,160 +87,173 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="6" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot27/Ui_PWSlot27.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot27/Ui_PWSlot27.py
@@ -19,7 +19,7 @@ class Ui_PWSlot27(object):
     def setupUi(self, PWSlot27):
         if not PWSlot27.objectName():
             PWSlot27.setObjectName(u"PWSlot27")
-        PWSlot27.resize(657, 470)
+        PWSlot27.resize(765, 470)
         PWSlot27.setMinimumSize(QSize(630, 470))
         PWSlot27.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot27)
@@ -60,133 +60,139 @@ class Ui_PWSlot27(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot27)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PWSlot27)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 3, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 3, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 3, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 4, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 4, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 4, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 5, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 5, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 5, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 6, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 6, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 6, 2, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_3.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_3.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_3.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot28/PWSlot28.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot28/PWSlot28.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>825</width>
     <height>470</height>
    </rect>
   </property>
@@ -86,126 +86,139 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_R1">
-          <property name="text">
-           <string>R1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_R1"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_R1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H3"/>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H3">
-          <property name="text">
-           <string>H3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W3"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W3">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W3">
-          <property name="text">
-           <string>W3</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_R1">
+           <property name="text">
+            <string>R1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_R1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_R1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H3"/>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H3">
+           <property name="text">
+            <string>H3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W3"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W3">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W3">
+           <property name="text">
+            <string>W3</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot28/Ui_PWSlot28.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot28/Ui_PWSlot28.py
@@ -19,7 +19,7 @@ class Ui_PWSlot28(object):
     def setupUi(self, PWSlot28):
         if not PWSlot28.objectName():
             PWSlot28.setObjectName(u"PWSlot28")
-        PWSlot28.resize(630, 470)
+        PWSlot28.resize(825, 470)
         PWSlot28.setMinimumSize(QSize(630, 470))
         PWSlot28.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot28)
@@ -60,85 +60,89 @@ class Ui_PWSlot28(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot28)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot28)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_R1 = QLabel(self.widget)
+        self.in_R1 = QLabel(self.scrollAreaWidgetContents)
         self.in_R1.setObjectName(u"in_R1")
 
         self.gridLayout.addWidget(self.in_R1, 4, 0, 1, 1)
 
-        self.lf_R1 = FloatEdit(self.widget)
+        self.lf_R1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_R1.setObjectName(u"lf_R1")
 
         self.gridLayout.addWidget(self.lf_R1, 4, 1, 1, 1)
 
-        self.unit_R1 = QLabel(self.widget)
+        self.unit_R1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_R1.setObjectName(u"unit_R1")
 
         self.gridLayout.addWidget(self.unit_R1, 4, 2, 1, 1)
 
-        self.unit_H3 = QLabel(self.widget)
+        self.unit_H3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H3.setObjectName(u"unit_H3")
 
         self.gridLayout.addWidget(self.unit_H3, 3, 2, 1, 1)
 
-        self.lf_H3 = FloatEdit(self.widget)
+        self.lf_H3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H3.setObjectName(u"lf_H3")
 
         self.gridLayout.addWidget(self.lf_H3, 3, 1, 1, 1)
 
-        self.in_H3 = QLabel(self.widget)
+        self.in_H3 = QLabel(self.scrollAreaWidgetContents)
         self.in_H3.setObjectName(u"in_H3")
 
         self.gridLayout.addWidget(self.in_H3, 3, 0, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 2, 2, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 2, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 2, 0, 1, 1)
 
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W3 = FloatEdit(self.widget)
+        self.lf_W3 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W3.setObjectName(u"lf_W3")
 
         self.gridLayout.addWidget(self.lf_W3, 1, 1, 1, 1)
 
-        self.unit_W3 = QLabel(self.widget)
+        self.unit_W3 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W3.setObjectName(u"unit_W3")
 
         self.gridLayout.addWidget(self.unit_W3, 1, 2, 1, 1)
 
-        self.in_W3 = QLabel(self.widget)
+        self.in_W3 = QLabel(self.scrollAreaWidgetContents)
         self.in_W3.setObjectName(u"in_W3")
 
         self.gridLayout.addWidget(self.in_W3, 1, 0, 1, 1)
@@ -151,12 +155,14 @@ class Ui_PWSlot28(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W3)
         QWidget.setTabOrder(self.lf_W3, self.lf_H0)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot29/PWSlot29.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot29/PWSlot29.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>854</width>
     <height>470</height>
    </rect>
   </property>
@@ -87,143 +87,156 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_W0">
-          <property name="text">
-           <string>W0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="FloatEdit" name="lf_W0"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="unit_W0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_W1">
-          <property name="text">
-           <string>W1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_W1"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_W1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_W2">
-          <property name="text">
-           <string>W2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_W2"/>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_W2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_H0">
-          <property name="text">
-           <string>H0</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_H0"/>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_H0">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_H1">
-          <property name="text">
-           <string>H1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_H1"/>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_H1">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_H2">
-          <property name="text">
-           <string>H2</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_H2"/>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_H2">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>446</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_W0">
+           <property name="text">
+            <string>W0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="FloatEdit" name="lf_W0"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="unit_W0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_W1">
+           <property name="text">
+            <string>W1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_W1"/>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_W1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_W2">
+           <property name="text">
+            <string>W2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_W2"/>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_W2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_H0">
+           <property name="text">
+            <string>H0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_H0"/>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_H0">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_H1">
+           <property name="text">
+            <string>H1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_H1"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_H1">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_H2">
+           <property name="text">
+            <string>H2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_H2"/>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_H2">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot29/Ui_PWSlot29.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlot29/Ui_PWSlot29.py
@@ -19,7 +19,7 @@ class Ui_PWSlot29(object):
     def setupUi(self, PWSlot29):
         if not PWSlot29.objectName():
             PWSlot29.setObjectName(u"PWSlot29")
-        PWSlot29.resize(630, 470)
+        PWSlot29.resize(854, 470)
         PWSlot29.setMinimumSize(QSize(630, 470))
         PWSlot29.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlot29)
@@ -60,100 +60,104 @@ class Ui_PWSlot29(object):
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
-        self.widget = QWidget(PWSlot29)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlot29)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 446))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_W0 = QLabel(self.widget)
+        self.in_W0 = QLabel(self.scrollAreaWidgetContents)
         self.in_W0.setObjectName(u"in_W0")
 
         self.gridLayout.addWidget(self.in_W0, 0, 0, 1, 1)
 
-        self.lf_W0 = FloatEdit(self.widget)
+        self.lf_W0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W0.setObjectName(u"lf_W0")
 
         self.gridLayout.addWidget(self.lf_W0, 0, 1, 1, 1)
 
-        self.unit_W0 = QLabel(self.widget)
+        self.unit_W0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W0.setObjectName(u"unit_W0")
 
         self.gridLayout.addWidget(self.unit_W0, 0, 2, 1, 1)
 
-        self.in_W1 = QLabel(self.widget)
+        self.in_W1 = QLabel(self.scrollAreaWidgetContents)
         self.in_W1.setObjectName(u"in_W1")
 
         self.gridLayout.addWidget(self.in_W1, 1, 0, 1, 1)
 
-        self.lf_W1 = FloatEdit(self.widget)
+        self.lf_W1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W1.setObjectName(u"lf_W1")
 
         self.gridLayout.addWidget(self.lf_W1, 1, 1, 1, 1)
 
-        self.unit_W1 = QLabel(self.widget)
+        self.unit_W1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W1.setObjectName(u"unit_W1")
 
         self.gridLayout.addWidget(self.unit_W1, 1, 2, 1, 1)
 
-        self.in_W2 = QLabel(self.widget)
+        self.in_W2 = QLabel(self.scrollAreaWidgetContents)
         self.in_W2.setObjectName(u"in_W2")
 
         self.gridLayout.addWidget(self.in_W2, 2, 0, 1, 1)
 
-        self.lf_W2 = FloatEdit(self.widget)
+        self.lf_W2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_W2.setObjectName(u"lf_W2")
 
         self.gridLayout.addWidget(self.lf_W2, 2, 1, 1, 1)
 
-        self.unit_W2 = QLabel(self.widget)
+        self.unit_W2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_W2.setObjectName(u"unit_W2")
 
         self.gridLayout.addWidget(self.unit_W2, 2, 2, 1, 1)
 
-        self.in_H0 = QLabel(self.widget)
+        self.in_H0 = QLabel(self.scrollAreaWidgetContents)
         self.in_H0.setObjectName(u"in_H0")
 
         self.gridLayout.addWidget(self.in_H0, 3, 0, 1, 1)
 
-        self.lf_H0 = FloatEdit(self.widget)
+        self.lf_H0 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H0.setObjectName(u"lf_H0")
 
         self.gridLayout.addWidget(self.lf_H0, 3, 1, 1, 1)
 
-        self.unit_H0 = QLabel(self.widget)
+        self.unit_H0 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H0.setObjectName(u"unit_H0")
 
         self.gridLayout.addWidget(self.unit_H0, 3, 2, 1, 1)
 
-        self.in_H1 = QLabel(self.widget)
+        self.in_H1 = QLabel(self.scrollAreaWidgetContents)
         self.in_H1.setObjectName(u"in_H1")
 
         self.gridLayout.addWidget(self.in_H1, 4, 0, 1, 1)
 
-        self.lf_H1 = FloatEdit(self.widget)
+        self.lf_H1 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H1.setObjectName(u"lf_H1")
 
         self.gridLayout.addWidget(self.lf_H1, 4, 1, 1, 1)
 
-        self.unit_H1 = QLabel(self.widget)
+        self.unit_H1 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H1.setObjectName(u"unit_H1")
 
         self.gridLayout.addWidget(self.unit_H1, 4, 2, 1, 1)
 
-        self.in_H2 = QLabel(self.widget)
+        self.in_H2 = QLabel(self.scrollAreaWidgetContents)
         self.in_H2.setObjectName(u"in_H2")
 
         self.gridLayout.addWidget(self.in_H2, 5, 0, 1, 1)
 
-        self.lf_H2 = FloatEdit(self.widget)
+        self.lf_H2 = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_H2.setObjectName(u"lf_H2")
 
         self.gridLayout.addWidget(self.lf_H2, 5, 1, 1, 1)
 
-        self.unit_H2 = QLabel(self.widget)
+        self.unit_H2 = QLabel(self.scrollAreaWidgetContents)
         self.unit_H2.setObjectName(u"unit_H2")
 
         self.gridLayout.addWidget(self.unit_H2, 5, 2, 1, 1)
@@ -166,12 +170,14 @@ class Ui_PWSlot29(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.lf_W0, self.lf_W1)
         QWidget.setTabOrder(self.lf_W1, self.lf_W2)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlotUD/PWSlotUD.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlotUD/PWSlotUD.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
+    <width>641</width>
     <height>440</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>740</width>
+    <width>0</width>
     <height>440</height>
    </size>
   </property>
@@ -30,54 +30,67 @@
     <widget class="MPLCanvas2" name="w_viewer" native="true"/>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QPushButton" name="b_dxf">
-        <property name="text">
-         <string>Define Slot from DXF</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="WPathSelectorV" name="w_path_json" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WWSlotOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>416</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QPushButton" name="b_dxf">
+         <property name="text">
+          <string>Define Slot from DXF</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="WPathSelectorV" name="w_path_json" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WWSlotOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlotUD/Ui_PWSlotUD.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/PWSlotUD/Ui_PWSlotUD.py
@@ -20,8 +20,8 @@ class Ui_PWSlotUD(object):
     def setupUi(self, PWSlotUD):
         if not PWSlotUD.objectName():
             PWSlotUD.setObjectName(u"PWSlotUD")
-        PWSlotUD.resize(740, 440)
-        PWSlotUD.setMinimumSize(QSize(740, 440))
+        PWSlotUD.resize(641, 440)
+        PWSlotUD.setMinimumSize(QSize(0, 440))
         PWSlotUD.setMaximumSize(QSize(16777215, 16777215))
         self.horizontalLayout = QHBoxLayout(PWSlotUD)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
@@ -30,18 +30,22 @@ class Ui_PWSlotUD(object):
 
         self.horizontalLayout.addWidget(self.w_viewer)
 
-        self.widget = QWidget(PWSlotUD)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PWSlotUD)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 416))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.b_dxf = QPushButton(self.widget)
+        self.b_dxf = QPushButton(self.scrollAreaWidgetContents)
         self.b_dxf.setObjectName(u"b_dxf")
 
         self.verticalLayout.addWidget(self.b_dxf)
 
-        self.w_path_json = WPathSelectorV(self.widget)
+        self.w_path_json = WPathSelectorV(self.scrollAreaWidgetContents)
         self.w_path_json.setObjectName(u"w_path_json")
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
@@ -57,12 +61,14 @@ class Ui_PWSlotUD(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WWSlotOut(self.widget)
+        self.w_out = WWSlotOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         self.retranslateUi(PWSlotUD)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/WWSlotOut/WWSlotOut.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWSlot/WWSlotOut/WWSlotOut.py
@@ -53,12 +53,12 @@ class WWSlotOut(QGroupBox):
             A WWSlotOut object
         """
 
-        if self.parent() is not None and hasattr(self.parent(), "lamination"):
-            parent = self.parent()
-            lam = self.parent().lamination
-        else:
-            parent = self.parent().parent()
-            lam = self.parent().parent().lamination
+        obj = self
+        while not hasattr(obj.parent(), "lamination") or obj.parent() is None:
+            obj = obj.parent()
+        parent = obj.parent()
+        lam = parent.lamination
+
         if lam.is_stator:
             lam_name = "Stator"
         else:

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType11/PCondType11.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType11/PCondType11.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1243</width>
-    <height>544</height>
+    <width>939</width>
+    <height>502</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,309 +40,322 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_Nwpc1_tan">
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Nwppc_tan</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QSpinBox" name="si_Nwpc1_tan">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="value">
-           <number>99</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Nwpc1_rad">
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Nwppc_rad</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="si_Nwpc1_rad">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="value">
-           <number>99</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_Wwire">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Wwire</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_Wwire">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>100</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_Wwire">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Hwire">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Hwire</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Hwire">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>100</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Hwire">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_Wins_wire">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Wins_wire</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_Wins_wire">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>100</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_Wins_wire">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="in_Lewout">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="whatsThis">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="text">
-           <string>Lewout</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="FloatEdit" name="lf_Lewout">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>100</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="whatsThis">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="unit_Lewout">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="whatsThis">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WCondOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>478</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_Nwpc1_tan">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Nwppc_tan</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="si_Nwpc1_tan">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="value">
+            <number>99</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Nwpc1_rad">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Nwppc_rad</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="si_Nwpc1_rad">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="value">
+            <number>99</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_Wwire">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Wwire</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_Wwire">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>100</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_Wwire">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Hwire">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Hwire</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Hwire">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>100</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Hwire">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_Wins_wire">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Wins_wire</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_Wins_wire">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>100</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_Wins_wire">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="in_Lewout">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="whatsThis">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="text">
+            <string>Lewout</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="FloatEdit" name="lf_Lewout">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>100</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="whatsThis">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="unit_Lewout">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="whatsThis">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WCondOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType11/Ui_PCondType11.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType11/Ui_PCondType11.py
@@ -19,7 +19,7 @@ class Ui_PCondType11(object):
     def setupUi(self, PCondType11):
         if not PCondType11.objectName():
             PCondType11.setObjectName(u"PCondType11")
-        PCondType11.resize(1243, 544)
+        PCondType11.resize(939, 502)
         self.horizontalLayout = QHBoxLayout(PCondType11)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.img_cond = QLabel(PCondType11)
@@ -33,21 +33,25 @@ class Ui_PCondType11(object):
 
         self.horizontalLayout.addWidget(self.img_cond)
 
-        self.widget = QWidget(PCondType11)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.scrollArea = QScrollArea(PCondType11)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 478))
+        self.verticalLayout_2 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_Nwpc1_tan = QLabel(self.widget)
+        self.in_Nwpc1_tan = QLabel(self.scrollAreaWidgetContents)
         self.in_Nwpc1_tan.setObjectName(u"in_Nwpc1_tan")
-        self.in_Nwpc1_tan.setMinimumSize(QSize(70, 0))
+        self.in_Nwpc1_tan.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Nwpc1_tan, 0, 0, 1, 1)
 
-        self.si_Nwpc1_tan = QSpinBox(self.widget)
+        self.si_Nwpc1_tan = QSpinBox(self.scrollAreaWidgetContents)
         self.si_Nwpc1_tan.setObjectName(u"si_Nwpc1_tan")
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
@@ -59,13 +63,13 @@ class Ui_PCondType11(object):
 
         self.gridLayout.addWidget(self.si_Nwpc1_tan, 0, 1, 1, 1)
 
-        self.in_Nwpc1_rad = QLabel(self.widget)
+        self.in_Nwpc1_rad = QLabel(self.scrollAreaWidgetContents)
         self.in_Nwpc1_rad.setObjectName(u"in_Nwpc1_rad")
-        self.in_Nwpc1_rad.setMinimumSize(QSize(70, 0))
+        self.in_Nwpc1_rad.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Nwpc1_rad, 1, 0, 1, 1)
 
-        self.si_Nwpc1_rad = QSpinBox(self.widget)
+        self.si_Nwpc1_rad = QSpinBox(self.scrollAreaWidgetContents)
         self.si_Nwpc1_rad.setObjectName(u"si_Nwpc1_rad")
         sizePolicy.setHeightForWidth(self.si_Nwpc1_rad.sizePolicy().hasHeightForWidth())
         self.si_Nwpc1_rad.setSizePolicy(sizePolicy)
@@ -73,13 +77,13 @@ class Ui_PCondType11(object):
 
         self.gridLayout.addWidget(self.si_Nwpc1_rad, 1, 1, 1, 1)
 
-        self.in_Wwire = QLabel(self.widget)
+        self.in_Wwire = QLabel(self.scrollAreaWidgetContents)
         self.in_Wwire.setObjectName(u"in_Wwire")
-        self.in_Wwire.setMinimumSize(QSize(40, 0))
+        self.in_Wwire.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Wwire, 2, 0, 1, 1)
 
-        self.lf_Wwire = FloatEdit(self.widget)
+        self.lf_Wwire = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wwire.setObjectName(u"lf_Wwire")
         sizePolicy.setHeightForWidth(self.lf_Wwire.sizePolicy().hasHeightForWidth())
         self.lf_Wwire.setSizePolicy(sizePolicy)
@@ -88,19 +92,19 @@ class Ui_PCondType11(object):
 
         self.gridLayout.addWidget(self.lf_Wwire, 2, 1, 1, 1)
 
-        self.unit_Wwire = QLabel(self.widget)
+        self.unit_Wwire = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wwire.setObjectName(u"unit_Wwire")
         self.unit_Wwire.setMinimumSize(QSize(0, 0))
 
         self.gridLayout.addWidget(self.unit_Wwire, 2, 2, 1, 1)
 
-        self.in_Hwire = QLabel(self.widget)
+        self.in_Hwire = QLabel(self.scrollAreaWidgetContents)
         self.in_Hwire.setObjectName(u"in_Hwire")
-        self.in_Hwire.setMinimumSize(QSize(40, 0))
+        self.in_Hwire.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Hwire, 3, 0, 1, 1)
 
-        self.lf_Hwire = FloatEdit(self.widget)
+        self.lf_Hwire = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Hwire.setObjectName(u"lf_Hwire")
         sizePolicy.setHeightForWidth(self.lf_Hwire.sizePolicy().hasHeightForWidth())
         self.lf_Hwire.setSizePolicy(sizePolicy)
@@ -109,19 +113,19 @@ class Ui_PCondType11(object):
 
         self.gridLayout.addWidget(self.lf_Hwire, 3, 1, 1, 1)
 
-        self.unit_Hwire = QLabel(self.widget)
+        self.unit_Hwire = QLabel(self.scrollAreaWidgetContents)
         self.unit_Hwire.setObjectName(u"unit_Hwire")
         self.unit_Hwire.setMinimumSize(QSize(0, 0))
 
         self.gridLayout.addWidget(self.unit_Hwire, 3, 2, 1, 1)
 
-        self.in_Wins_wire = QLabel(self.widget)
+        self.in_Wins_wire = QLabel(self.scrollAreaWidgetContents)
         self.in_Wins_wire.setObjectName(u"in_Wins_wire")
-        self.in_Wins_wire.setMinimumSize(QSize(40, 0))
+        self.in_Wins_wire.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Wins_wire, 4, 0, 1, 1)
 
-        self.lf_Wins_wire = FloatEdit(self.widget)
+        self.lf_Wins_wire = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wins_wire.setObjectName(u"lf_Wins_wire")
         sizePolicy.setHeightForWidth(self.lf_Wins_wire.sizePolicy().hasHeightForWidth())
         self.lf_Wins_wire.setSizePolicy(sizePolicy)
@@ -130,19 +134,19 @@ class Ui_PCondType11(object):
 
         self.gridLayout.addWidget(self.lf_Wins_wire, 4, 1, 1, 1)
 
-        self.unit_Wins_wire = QLabel(self.widget)
+        self.unit_Wins_wire = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wins_wire.setObjectName(u"unit_Wins_wire")
         self.unit_Wins_wire.setMinimumSize(QSize(0, 0))
 
         self.gridLayout.addWidget(self.unit_Wins_wire, 4, 2, 1, 1)
 
-        self.in_Lewout = QLabel(self.widget)
+        self.in_Lewout = QLabel(self.scrollAreaWidgetContents)
         self.in_Lewout.setObjectName(u"in_Lewout")
-        self.in_Lewout.setMinimumSize(QSize(40, 0))
+        self.in_Lewout.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Lewout, 5, 0, 1, 1)
 
-        self.lf_Lewout = FloatEdit(self.widget)
+        self.lf_Lewout = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Lewout.setObjectName(u"lf_Lewout")
         sizePolicy.setHeightForWidth(self.lf_Lewout.sizePolicy().hasHeightForWidth())
         self.lf_Lewout.setSizePolicy(sizePolicy)
@@ -151,26 +155,28 @@ class Ui_PCondType11(object):
 
         self.gridLayout.addWidget(self.lf_Lewout, 5, 1, 1, 1)
 
-        self.unit_Lewout = QLabel(self.widget)
+        self.unit_Lewout = QLabel(self.scrollAreaWidgetContents)
         self.unit_Lewout.setObjectName(u"unit_Lewout")
         self.unit_Lewout.setMinimumSize(QSize(0, 0))
 
         self.gridLayout.addWidget(self.unit_Lewout, 5, 2, 1, 1)
 
-        self.verticalLayout.addLayout(self.gridLayout)
+        self.verticalLayout_2.addLayout(self.gridLayout)
 
         self.verticalSpacer = QSpacerItem(
             20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
         )
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_2.addItem(self.verticalSpacer)
 
-        self.w_out = WCondOut(self.widget)
+        self.w_out = WCondOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
-        self.verticalLayout.addWidget(self.w_out)
+        self.verticalLayout_2.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.si_Nwpc1_tan, self.si_Nwpc1_rad)
         QWidget.setTabOrder(self.si_Nwpc1_rad, self.lf_Wwire)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType12/PCondType12.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType12/PCondType12.ui
@@ -40,241 +40,260 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="minimumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
+       <width>270</width>
        <height>16777215</height>
       </size>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="in_Nwpc1">
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Nwppc</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QSpinBox" name="si_Nwpc1">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="value">
-           <number>99</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="in_Wwire">
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Wwire</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="FloatEdit" name="lf_Wwire">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="unit_Wwire">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="in_Wins_wire">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Wins_wire</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="FloatEdit" name="lf_Wins_wire">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="unit_Wins_wire">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="in_Wins_cond">
-          <property name="text">
-           <string>Wins_cond</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="FloatEdit" name="lf_Wins_cond">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="unit_Wins_cond">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="in_Lewout">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="whatsThis">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="text">
-           <string>Lewout</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="FloatEdit" name="lf_Lewout">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="whatsThis">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QLabel" name="unit_Lewout">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="whatsThis">
-           <string>End-winding length on one side for a half-turn</string>
-          </property>
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="WCondOut" name="w_out" native="true"/>
-      </item>
-     </layout>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>268</width>
+        <height>648</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="in_Nwpc1">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Nwppc</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="si_Nwpc1">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="value">
+            <number>99</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="in_Wwire">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Wwire</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="FloatEdit" name="lf_Wwire">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="unit_Wwire">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="in_Wins_wire">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Wins_wire</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="FloatEdit" name="lf_Wins_wire">
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="unit_Wins_wire">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="in_Wins_cond">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Wins_cond</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="FloatEdit" name="lf_Wins_cond">
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QLabel" name="unit_Wins_cond">
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="in_Lewout">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="whatsThis">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="text">
+            <string>Lewout</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="FloatEdit" name="lf_Lewout">
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="whatsThis">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="unit_Lewout">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="whatsThis">
+            <string>End-winding length on one side for a half-turn</string>
+           </property>
+           <property name="text">
+            <string>m</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="WCondOut" name="w_out" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType12/Ui_PCondType12.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/PCondType12/Ui_PCondType12.py
@@ -33,96 +33,101 @@ class Ui_PCondType12(object):
 
         self.horizontalLayout.addWidget(self.img_cond)
 
-        self.widget = QWidget(PCondType12)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout = QVBoxLayout(self.widget)
+        self.scrollArea = QScrollArea(PCondType12)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 648))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.in_Nwpc1 = QLabel(self.widget)
+        self.in_Nwpc1 = QLabel(self.scrollAreaWidgetContents)
         self.in_Nwpc1.setObjectName(u"in_Nwpc1")
-        self.in_Nwpc1.setMinimumSize(QSize(70, 0))
+        self.in_Nwpc1.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Nwpc1, 0, 0, 1, 1)
 
-        self.si_Nwpc1 = QSpinBox(self.widget)
+        self.si_Nwpc1 = QSpinBox(self.scrollAreaWidgetContents)
         self.si_Nwpc1.setObjectName(u"si_Nwpc1")
         self.si_Nwpc1.setMinimumSize(QSize(0, 0))
         self.si_Nwpc1.setValue(99)
 
         self.gridLayout.addWidget(self.si_Nwpc1, 0, 1, 1, 1)
 
-        self.in_Wwire = QLabel(self.widget)
+        self.in_Wwire = QLabel(self.scrollAreaWidgetContents)
         self.in_Wwire.setObjectName(u"in_Wwire")
-        self.in_Wwire.setMinimumSize(QSize(70, 0))
+        self.in_Wwire.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Wwire, 1, 0, 1, 1)
 
-        self.lf_Wwire = FloatEdit(self.widget)
+        self.lf_Wwire = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wwire.setObjectName(u"lf_Wwire")
         self.lf_Wwire.setMinimumSize(QSize(0, 0))
         self.lf_Wwire.setMaximumSize(QSize(16777215, 16777215))
 
         self.gridLayout.addWidget(self.lf_Wwire, 1, 1, 1, 1)
 
-        self.unit_Wwire = QLabel(self.widget)
+        self.unit_Wwire = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wwire.setObjectName(u"unit_Wwire")
         self.unit_Wwire.setMinimumSize(QSize(0, 0))
 
         self.gridLayout.addWidget(self.unit_Wwire, 1, 2, 1, 1)
 
-        self.in_Wins_wire = QLabel(self.widget)
+        self.in_Wins_wire = QLabel(self.scrollAreaWidgetContents)
         self.in_Wins_wire.setObjectName(u"in_Wins_wire")
-        self.in_Wins_wire.setMinimumSize(QSize(40, 0))
+        self.in_Wins_wire.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Wins_wire, 2, 0, 1, 1)
 
-        self.lf_Wins_wire = FloatEdit(self.widget)
+        self.lf_Wins_wire = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wins_wire.setObjectName(u"lf_Wins_wire")
         self.lf_Wins_wire.setMinimumSize(QSize(50, 0))
         self.lf_Wins_wire.setMaximumSize(QSize(16777215, 16777215))
 
         self.gridLayout.addWidget(self.lf_Wins_wire, 2, 1, 1, 1)
 
-        self.unit_Wins_wire = QLabel(self.widget)
+        self.unit_Wins_wire = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wins_wire.setObjectName(u"unit_Wins_wire")
         self.unit_Wins_wire.setMinimumSize(QSize(0, 0))
 
         self.gridLayout.addWidget(self.unit_Wins_wire, 2, 2, 1, 1)
 
-        self.in_Wins_cond = QLabel(self.widget)
+        self.in_Wins_cond = QLabel(self.scrollAreaWidgetContents)
         self.in_Wins_cond.setObjectName(u"in_Wins_cond")
+        self.in_Wins_cond.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Wins_cond, 3, 0, 1, 1)
 
-        self.lf_Wins_cond = FloatEdit(self.widget)
+        self.lf_Wins_cond = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Wins_cond.setObjectName(u"lf_Wins_cond")
         self.lf_Wins_cond.setMinimumSize(QSize(50, 0))
         self.lf_Wins_cond.setMaximumSize(QSize(16777215, 16777215))
 
         self.gridLayout.addWidget(self.lf_Wins_cond, 3, 1, 1, 1)
 
-        self.unit_Wins_cond = QLabel(self.widget)
+        self.unit_Wins_cond = QLabel(self.scrollAreaWidgetContents)
         self.unit_Wins_cond.setObjectName(u"unit_Wins_cond")
 
         self.gridLayout.addWidget(self.unit_Wins_cond, 3, 2, 1, 1)
 
-        self.in_Lewout = QLabel(self.widget)
+        self.in_Lewout = QLabel(self.scrollAreaWidgetContents)
         self.in_Lewout.setObjectName(u"in_Lewout")
-        self.in_Lewout.setMinimumSize(QSize(40, 0))
+        self.in_Lewout.setMinimumSize(QSize(90, 0))
 
         self.gridLayout.addWidget(self.in_Lewout, 4, 0, 1, 1)
 
-        self.lf_Lewout = FloatEdit(self.widget)
+        self.lf_Lewout = FloatEdit(self.scrollAreaWidgetContents)
         self.lf_Lewout.setObjectName(u"lf_Lewout")
         self.lf_Lewout.setMinimumSize(QSize(50, 0))
         self.lf_Lewout.setMaximumSize(QSize(16777215, 16777215))
 
         self.gridLayout.addWidget(self.lf_Lewout, 4, 1, 1, 1)
 
-        self.unit_Lewout = QLabel(self.widget)
+        self.unit_Lewout = QLabel(self.scrollAreaWidgetContents)
         self.unit_Lewout.setObjectName(u"unit_Lewout")
         self.unit_Lewout.setMinimumSize(QSize(0, 0))
 
@@ -136,12 +141,14 @@ class Ui_PCondType12(object):
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.w_out = WCondOut(self.widget)
+        self.w_out = WCondOut(self.scrollAreaWidgetContents)
         self.w_out.setObjectName(u"w_out")
 
         self.verticalLayout.addWidget(self.w_out)
 
-        self.horizontalLayout.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.horizontalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.si_Nwpc1, self.lf_Wwire)
         QWidget.setTabOrder(self.lf_Wwire, self.lf_Wins_wire)

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/WCondOut/WCondOut.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWindCond/WCondOut/WCondOut.py
@@ -48,7 +48,12 @@ class WCondOut(QGroupBox):
             A WCondOut object
         """
 
-        lam = self.parent().parent().lam
+        obj = self
+        while not hasattr(obj.parent(), "lam") or obj.parent() is None:
+            obj = obj.parent()
+        parent = obj.parent()
+        lam = parent.lam
+
         H_txt = self.tr("Hcond = ")
         W_txt = self.tr("Wcond = ")
         S_txt = self.tr("Scond = ")
@@ -58,7 +63,7 @@ class WCondOut(QGroupBox):
         else:
             K_txt = self.tr("Krfill = ")
         # We compute the output only if the slot is correctly set
-        if self.parent().parent().check() is None:
+        if parent.check() is None:
             # Compute all the needed output as string
             H = format(self.u.get_m(lam.winding.conductor.comp_height()), ".4g")
             W = format(self.u.get_m(lam.winding.conductor.comp_width()), ".4g")

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWinding/SWinding.ui
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWinding/SWinding.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1158</width>
-    <height>758</height>
+    <width>993</width>
+    <height>837</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -19,11 +19,18 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_5">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
-      <widget class="MPLCanvas2" name="w_viewer" native="true"/>
+      <widget class="MPLCanvas2" name="w_viewer" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>250</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="in_wind_param">
@@ -45,314 +52,327 @@
       </widget>
      </item>
      <item>
-      <widget class="QWidget" name="widget" native="true">
+      <widget class="QScrollArea" name="scrollArea">
        <property name="minimumSize">
         <size>
-         <width>250</width>
+         <width>270</width>
          <height>0</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>250</width>
+         <width>270</width>
          <height>16777215</height>
         </size>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-         <widget class="QGroupBox" name="g_pattern">
-          <property name="title">
-           <string>Pattern</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <item>
-            <widget class="QComboBox" name="c_wind_type">
-             <item>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>268</width>
+          <height>774</height>
+         </rect>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <widget class="QGroupBox" name="g_pattern">
+           <property name="title">
+            <string>Pattern</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QComboBox" name="c_wind_type">
+              <item>
+               <property name="text">
+                <string>Star of Slot</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>User Defined</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="in_Zs">
               <property name="text">
-               <string>Star of Slot</string>
+               <string>Slot number=123</string>
               </property>
-             </item>
-             <item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="in_p">
               <property name="text">
-               <string>User Defined</string>
+               <string>Pole pair number=32</string>
               </property>
-             </item>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="in_Zs">
-             <property name="text">
-              <string>Slot number=123</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="in_p">
-             <property name="text">
-              <string>Pole pair number=32</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QGridLayout" name="gridLayout">
-             <item row="0" column="0">
-              <widget class="QLabel" name="in_qs">
-               <property name="text">
-                <string>Phases number</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QSpinBox" name="si_qs"/>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="in_Nlayer">
-               <property name="text">
-                <string>Layer number</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="si_Nlayer">
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>2</number>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="in_coil_pitch">
-               <property name="text">
-                <string>Coil pitch</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QSpinBox" name="si_coil_pitch"/>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="in_Ntcoil">
-               <property name="text">
-                <string>Turns per coil</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QSpinBox" name="si_Ntcoil"/>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="in_Npcp">
-               <property name="text">
-                <string>Parallel circuits</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QSpinBox" name="si_Npcp">
-               <property name="maximum">
-                <number>999999999</number>
-               </property>
-               <property name="value">
-                <number>12345</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QPushButton" name="b_generate">
-             <property name="text">
-              <string>Generate</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="b_import">
-             <property name="text">
-              <string>Import from CSV</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="g_edit">
-          <property name="title">
-           <string>Edit</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_4">
-             <item>
-              <widget class="QLabel" name="in_Nslot">
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>Slot shift</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="si_Nslot">
-               <property name="minimumSize">
-                <size>
-                 <width>60</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="is_permute_B_C">
-             <property name="text">
-              <string>Permute B-C phases</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="is_reverse">
-             <property name="text">
-              <string>Reverse winding</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="is_reverse_layer">
-             <property name="text">
-              <string>Reverse layer</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="is_change_layer">
-             <property name="text">
-              <string>Change layer direction</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="b_edit_wind_mat">
-             <property name="text">
-              <string>Edit Winding Matrix</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="g_output">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="title">
-           <string>Output</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_3">
-           <item>
-            <widget class="QLabel" name="out_rot_dir">
-             <property name="minimumSize">
-              <size>
-               <width>175</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Rotation Direction: </string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="out_ms">
-             <property name="text">
-              <string>ms = Zs / (2*p*qs) = ?</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="out_Nperw">
-             <property name="toolTip">
-              <string>Winding periodicity</string>
-             </property>
-             <property name="text">
-              <string>Nperw</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="out_Ntspc">
-             <property name="toolTip">
-              <string>Winding number of turns in series per phase</string>
-             </property>
-             <property name="statusTip">
-              <string>Winding number of turns in series per phase</string>
-             </property>
-             <property name="whatsThis">
-              <string>Winding number of turns in series per phase</string>
-             </property>
-             <property name="text">
-              <string>Ntspc: </string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="out_Ncspc">
-             <property name="toolTip">
-              <string>Number of coils in series per parallel circuit</string>
-             </property>
-             <property name="statusTip">
-              <string>Number of coils in series per parallel circuit</string>
-             </property>
-             <property name="whatsThis">
-              <string>Number of coils in series per parallel circuit</string>
-             </property>
-             <property name="text">
-              <string>Ncspc:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="b_export">
-             <property name="text">
-              <string>Export to CSV</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
+             </widget>
+            </item>
+            <item>
+             <layout class="QGridLayout" name="gridLayout">
+              <item row="0" column="0">
+               <widget class="QLabel" name="in_qs">
+                <property name="text">
+                 <string>Phases number</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="si_qs"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="in_Nlayer">
+                <property name="text">
+                 <string>Layer number</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QSpinBox" name="si_Nlayer">
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>2</number>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="in_coil_pitch">
+                <property name="text">
+                 <string>Coil pitch</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QSpinBox" name="si_coil_pitch"/>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="in_Ntcoil">
+                <property name="text">
+                 <string>Turns per coil</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QSpinBox" name="si_Ntcoil"/>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="in_Npcp">
+                <property name="text">
+                 <string>Parallel circuits</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QSpinBox" name="si_Npcp">
+                <property name="maximum">
+                 <number>999999999</number>
+                </property>
+                <property name="value">
+                 <number>12345</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QPushButton" name="b_generate">
+              <property name="text">
+               <string>Generate</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="b_import">
+              <property name="text">
+               <string>Import from CSV</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="g_edit">
+           <property name="title">
+            <string>Edit</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_4">
+              <item>
+               <widget class="QLabel" name="in_Nslot">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Slot shift</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="si_Nslot">
+                <property name="minimumSize">
+                 <size>
+                  <width>60</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="is_permute_B_C">
+              <property name="text">
+               <string>Permute B-C phases</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="is_reverse">
+              <property name="text">
+               <string>Reverse winding</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="is_reverse_layer">
+              <property name="text">
+               <string>Reverse layer</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="is_change_layer">
+              <property name="text">
+               <string>Change layer direction</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="b_edit_wind_mat">
+              <property name="text">
+               <string>Edit Winding Matrix</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="g_output">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Output</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <item>
+             <widget class="QLabel" name="out_rot_dir">
+              <property name="minimumSize">
+               <size>
+                <width>175</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Rotation Direction: </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="out_ms">
+              <property name="text">
+               <string>ms = Zs / (2*p*qs) = ?</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="out_Nperw">
+              <property name="toolTip">
+               <string>Winding periodicity</string>
+              </property>
+              <property name="text">
+               <string>Nperw</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="out_Ntspc">
+              <property name="toolTip">
+               <string>Winding number of turns in series per phase</string>
+              </property>
+              <property name="statusTip">
+               <string>Winding number of turns in series per phase</string>
+              </property>
+              <property name="whatsThis">
+               <string>Winding number of turns in series per phase</string>
+              </property>
+              <property name="text">
+               <string>Ntspc: </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="out_Ncspc">
+              <property name="toolTip">
+               <string>Number of coils in series per parallel circuit</string>
+              </property>
+              <property name="statusTip">
+               <string>Number of coils in series per parallel circuit</string>
+              </property>
+              <property name="whatsThis">
+               <string>Number of coils in series per parallel circuit</string>
+              </property>
+              <property name="text">
+               <string>Ncspc:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="b_export">
+              <property name="text">
+               <string>Export to CSV</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>

--- a/pyleecan/GUI/Dialog/DMachineSetup/SWinding/Ui_SWinding.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SWinding/Ui_SWinding.py
@@ -18,14 +18,15 @@ class Ui_SWinding(object):
     def setupUi(self, SWinding):
         if not SWinding.objectName():
             SWinding.setObjectName(u"SWinding")
-        SWinding.resize(1158, 758)
+        SWinding.resize(993, 837)
         SWinding.setMinimumSize(QSize(650, 550))
-        self.verticalLayout_5 = QVBoxLayout(SWinding)
-        self.verticalLayout_5.setObjectName(u"verticalLayout_5")
+        self.verticalLayout_4 = QVBoxLayout(SWinding)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
         self.horizontalLayout_8 = QHBoxLayout()
         self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
         self.w_viewer = MPLCanvas2(SWinding)
         self.w_viewer.setObjectName(u"w_viewer")
+        self.w_viewer.setMinimumSize(QSize(250, 0))
 
         self.horizontalLayout_8.addWidget(self.w_viewer)
 
@@ -39,13 +40,17 @@ class Ui_SWinding(object):
 
         self.horizontalLayout_8.addWidget(self.in_wind_param)
 
-        self.widget = QWidget(SWinding)
-        self.widget.setObjectName(u"widget")
-        self.widget.setMinimumSize(QSize(250, 0))
-        self.widget.setMaximumSize(QSize(250, 16777215))
-        self.verticalLayout_4 = QVBoxLayout(self.widget)
-        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
-        self.g_pattern = QGroupBox(self.widget)
+        self.scrollArea = QScrollArea(SWinding)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setMinimumSize(QSize(270, 0))
+        self.scrollArea.setMaximumSize(QSize(270, 16777215))
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 268, 774))
+        self.verticalLayout_5 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_5.setObjectName(u"verticalLayout_5")
+        self.g_pattern = QGroupBox(self.scrollAreaWidgetContents)
         self.g_pattern.setObjectName(u"g_pattern")
         self.verticalLayout_2 = QVBoxLayout(self.g_pattern)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
@@ -134,9 +139,15 @@ class Ui_SWinding(object):
 
         self.verticalLayout_2.addWidget(self.b_import)
 
-        self.verticalLayout_4.addWidget(self.g_pattern)
+        self.verticalLayout_5.addWidget(self.g_pattern)
 
-        self.g_edit = QGroupBox(self.widget)
+        self.verticalSpacer = QSpacerItem(
+            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
+        )
+
+        self.verticalLayout_5.addItem(self.verticalSpacer)
+
+        self.g_edit = QGroupBox(self.scrollAreaWidgetContents)
         self.g_edit.setObjectName(u"g_edit")
         self.verticalLayout = QVBoxLayout(self.g_edit)
         self.verticalLayout.setObjectName(u"verticalLayout")
@@ -182,15 +193,9 @@ class Ui_SWinding(object):
 
         self.verticalLayout.addWidget(self.b_edit_wind_mat)
 
-        self.verticalLayout_4.addWidget(self.g_edit)
+        self.verticalLayout_5.addWidget(self.g_edit)
 
-        self.verticalSpacer = QSpacerItem(
-            20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding
-        )
-
-        self.verticalLayout_4.addItem(self.verticalSpacer)
-
-        self.g_output = QGroupBox(self.widget)
+        self.g_output = QGroupBox(self.scrollAreaWidgetContents)
         self.g_output.setObjectName(u"g_output")
         self.g_output.setMinimumSize(QSize(200, 0))
         self.verticalLayout_3 = QVBoxLayout(self.g_output)
@@ -226,11 +231,13 @@ class Ui_SWinding(object):
 
         self.verticalLayout_3.addWidget(self.b_export)
 
-        self.verticalLayout_4.addWidget(self.g_output)
+        self.verticalLayout_5.addWidget(self.g_output)
 
-        self.horizontalLayout_8.addWidget(self.widget)
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
 
-        self.verticalLayout_5.addLayout(self.horizontalLayout_8)
+        self.horizontalLayout_8.addWidget(self.scrollArea)
+
+        self.verticalLayout_4.addLayout(self.horizontalLayout_8)
 
         self.horizontalLayout_3 = QHBoxLayout()
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
@@ -255,7 +262,7 @@ class Ui_SWinding(object):
 
         self.horizontalLayout_3.addWidget(self.b_next)
 
-        self.verticalLayout_5.addLayout(self.horizontalLayout_3)
+        self.verticalLayout_4.addLayout(self.horizontalLayout_3)
 
         self.retranslateUi(SWinding)
 

--- a/pyleecan/GUI/Dialog/DMachineSetup/Ui_DMachineSetup.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/Ui_DMachineSetup.py
@@ -16,9 +16,16 @@ class Ui_DMachineSetup(object):
     def setupUi(self, DMachineSetup):
         if not DMachineSetup.objectName():
             DMachineSetup.setObjectName(u"DMachineSetup")
-        DMachineSetup.resize(1001, 721)
-        self.horizontalLayout_2 = QHBoxLayout(DMachineSetup)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        DMachineSetup.resize(1076, 682)
+        self.main_layout = QHBoxLayout(DMachineSetup)
+        self.main_layout.setObjectName(u"main_layout")
+        self.verticalLayout = QVBoxLayout()
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.b_load = QPushButton(DMachineSetup)
+        self.b_load.setObjectName(u"b_load")
+
+        self.verticalLayout.addWidget(self.b_load)
+
         self.nav_step = QListWidget(DMachineSetup)
         self.nav_step.setObjectName(u"nav_step")
         sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
@@ -28,29 +35,14 @@ class Ui_DMachineSetup(object):
         self.nav_step.setSizePolicy(sizePolicy)
         self.nav_step.setMaximumSize(QSize(190, 16777215))
 
-        self.horizontalLayout_2.addWidget(self.nav_step)
-
-        self.main_layout = QVBoxLayout()
-        self.main_layout.setObjectName(u"main_layout")
-        self.horizontalLayout = QHBoxLayout()
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.horizontalSpacer = QSpacerItem(
-            40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
-        )
-
-        self.horizontalLayout.addItem(self.horizontalSpacer)
+        self.verticalLayout.addWidget(self.nav_step)
 
         self.b_save = QPushButton(DMachineSetup)
         self.b_save.setObjectName(u"b_save")
 
-        self.horizontalLayout.addWidget(self.b_save)
+        self.verticalLayout.addWidget(self.b_save)
 
-        self.b_load = QPushButton(DMachineSetup)
-        self.b_load.setObjectName(u"b_load")
-
-        self.horizontalLayout.addWidget(self.b_load)
-
-        self.main_layout.addLayout(self.horizontalLayout)
+        self.main_layout.addLayout(self.verticalLayout)
 
         self.w_step = QWidget(DMachineSetup)
         self.w_step.setObjectName(u"w_step")
@@ -63,8 +55,6 @@ class Ui_DMachineSetup(object):
 
         self.main_layout.addWidget(self.w_step)
 
-        self.horizontalLayout_2.addLayout(self.main_layout)
-
         self.retranslateUi(DMachineSetup)
 
         QMetaObject.connectSlotsByName(DMachineSetup)
@@ -75,7 +65,7 @@ class Ui_DMachineSetup(object):
         DMachineSetup.setWindowTitle(
             QCoreApplication.translate("DMachineSetup", u"Pyleecan Machine Setup", None)
         )
-        self.b_save.setText(QCoreApplication.translate("DMachineSetup", u"Save", None))
         self.b_load.setText(QCoreApplication.translate("DMachineSetup", u"Load", None))
+        self.b_save.setText(QCoreApplication.translate("DMachineSetup", u"Save", None))
 
     # retranslateUi

--- a/pyleecan/Methods/Slot/SlotM17/check.py
+++ b/pyleecan/Methods/Slot/SlotM17/check.py
@@ -20,7 +20,7 @@ def check(self):
     if self.parent is None:
         raise SlotCheckError("SlotM17 must be inside a lamination")
     if self.Zs != 2:
-        raise SlotCheckError("SlotM17 must have Zs=2")
+        raise SlotCheckError("SlotM17 must have p=1")
     if not self.parent.is_internal or self.parent.Rint != 0:
         raise SlotCheckError(
             "SlotM17 must be inside an internal lamination with Rint=0"


### PR DESCRIPTION
Hello all,

The point of this PR is to improve the resize behaviour of the GUI (sadly it is not yet the images). Now the "right columns" are scroll area : if the widget height is not enough, a scroll bar will be added. To save some height for the step widget, the save / load buttons are now on the left column.

Before:
![image](https://user-images.githubusercontent.com/20533034/118889034-c9b0ab00-b8fc-11eb-83f6-b70cf0429005.png)
![image](https://user-images.githubusercontent.com/20533034/118889053-d2a17c80-b8fc-11eb-8967-4729bb40a721.png)


Now:
![image](https://user-images.githubusercontent.com/20533034/118888488-04feaa00-b8fc-11eb-828d-37e7a4cdd023.png)
![image](https://user-images.githubusercontent.com/20533034/118888819-73436c80-b8fc-11eb-9fdd-5a27c7dda5ba.png)

To go further on the vertical behaviour of the GUI see #385 

Best regards,
Pierre
PS : I plan to merge this PR and #386 on Friday and release pyleecan 1.3.0 