### PR TITLE
[CO] Draw_FEMM_lamination

### DIFF
--- a/Tests/Functions/test_save_load.py
+++ b/Tests/Functions/test_save_load.py
@@ -432,8 +432,9 @@ def test_save_load_simu(type_file):
 
 
 if __name__ == "__main__":
-    test_save_load_DXF_flat()
-    print("Done")
-    # test_save_load_simu("json")
+    # test_save_load_DXF_flat()
+
+    test_save_load_simu("json")
     # test_save_load_simu("h5")
     # test_save_load_simu("pkl")
+    print("Done")

--- a/pyleecan/Functions/FEMM/comp_FEMM_dict.py
+++ b/pyleecan/Functions/FEMM/comp_FEMM_dict.py
@@ -5,6 +5,7 @@ from ...Classes.LamSlotMag import LamSlotMag
 from ...Classes.MachineSIPMSM import MachineSIPMSM
 from ...Functions.FEMM import acsolver, pbtype, precision, minangle
 from ...Functions.FEMM import FEMM_GROUPS
+from ...Functions.labels import ROTOR_LAB
 
 
 def comp_FEMM_dict(machine, Kgeo_fineness, Kmesh_fineness, type_calc_leakage=0):
@@ -31,103 +32,114 @@ def comp_FEMM_dict(machine, Kgeo_fineness, Kmesh_fineness, type_calc_leakage=0):
 
     """
 
-    # Recompute because machine may has been modified
-    Hsy = machine.stator.comp_height_yoke()
-    Hs = machine.stator.Rext - machine.stator.Rint
-    Hstot = Hs - Hsy  # Works with holes and slot
-
-    Wgap_mec = machine.comp_width_airgap_mec()
-
-    Hry = machine.rotor.comp_height_yoke()
-    Hr = machine.rotor.Rext - machine.rotor.Rint
-    Hrtot = Hr - Hry  # Works with holes and slot
-
     FEMM_dict = dict()
-    FEMM_dict["is_close_model"] = 0
-    FEMM_dict["acsolver"] = acsolver
-    FEMM_dict["pbtype"] = pbtype
-    FEMM_dict["precision"] = precision
-    FEMM_dict["minangle"] = minangle
-    FEMM_dict["freqpb"] = 0  # setting 2D magnetostatic problem
+    # Gather the main Simulation/model related parameters
+    FEMM_dict["simu"] = dict()
+    if type_calc_leakage == 1:
+        FEMM_dict["simu"]["is_close_model"] = 1
+    else:
+        FEMM_dict["simu"]["is_close_model"] = 0
+    FEMM_dict["simu"]["acsolver"] = acsolver
+    FEMM_dict["simu"]["pbtype"] = pbtype
+    FEMM_dict["simu"]["precision"] = precision
+    FEMM_dict["simu"]["minangle"] = minangle
+    FEMM_dict["simu"]["freqpb"] = 0  # setting 2D magnetostatic problem
+    # assign unitary length to calculate torque and flux linkage per meter unit
+    FEMM_dict["simu"]["Lfemm"] = 1
 
-    FEMM_dict["smart_mesh"] = 0
-    FEMM_dict["automesh"] = 0  # 1 to let the solver define the mesh in all
+    # Gather all mesh related parameters
+    FEMM_dict["mesh"] = dict()
+    FEMM_dict["mesh"]["smart_mesh"] = 0
+    FEMM_dict["mesh"]["automesh"] = 0  # 1 to let the solver define the mesh in all
     # regions(except in the airgap), otherwise meshsize_XXX parameters are used
-    FEMM_dict["automesh_airgap"] = 0  # 1 to let the solver define the mesh in the
+    FEMM_dict["mesh"][
+        "automesh_airgap"
+    ] = 0  # 1 to let the solver define the mesh in the
     #  airgap, otherwise meshsize_airgap is used
-    FEMM_dict["automesh_segments"] = 0  # 1 to let the solver define the mesh
+    FEMM_dict["mesh"]["automesh_segments"] = 0  # 1 to let the solver define the mesh
     # points along arcs and segments, otherwise arcspan_XXX and
     # elementsize_XXX are used
 
-    FEMM_dict["maxsegdeg"] = 1  # max angular width of elementary segment along
+    FEMM_dict["mesh"]["maxsegdeg"] = 1  # max angular width of elementary segment along
     # arc discretization(default: 1)
-    FEMM_dict["maxelementsize"] = 1  # max length of elementary segment along
+    FEMM_dict["mesh"]["maxelementsize"] = 1  # max length of elementary segment along
     # segment discretization(1 for automatic meshing) "elementsize" in FEMM doc
-    FEMM_dict["arcspan"] = 1 / Kgeo_fineness  # max span of arc element in degrees
+    FEMM_dict["mesh"]["arcspan"] = (
+        1 / Kgeo_fineness
+    )  # max span of arc element in degrees
 
-    # assign unitary length to calculate torque and flux linkage per meter unit
-    FEMM_dict["Lfemm"] = 1
+    # Add all mesh size for all Laminations
+    for lam in machine.get_lam_list():
+        label = lam.get_label()
+        # Recompute because machine may has been modified
+        Hsy = lam.comp_height_yoke()
+        Hs = lam.Rext - lam.Rint
+        Hstot = Hs - Hsy  # Works with holes and slot
 
-    # stator slot region mesh and segments max element size parameter
-    # If Hstot = 0 there is no slot and the region parameter won't be used
-    FEMM_dict["meshsize_slotS"] = max(Hstot, Hs / 2) / 8 / Kmesh_fineness
-    FEMM_dict["elementsize_slotS"] = max(Hstot, Hs / 2) / 8 / Kmesh_fineness
+        # Store all the elements size for the lamination
+        FEMM_dict["mesh"][label] = dict()
+        if lam.is_stator:
+            # stator slot region mesh and segments max element size parameter
+            # If Hstot = 0 there is no slot and the region parameter won't be used
+            FEMM_dict["mesh"][label]["meshsize_slot"] = (
+                max(Hstot, Hs / 2) / 8 / Kmesh_fineness
+            )
+            FEMM_dict["mesh"][label]["elementsize_slot"] = (
+                max(Hstot, Hs / 2) / 8 / Kmesh_fineness
+            )
+            # stator yoke region mesh and segments max element size parameter
+            FEMM_dict["mesh"][label]["meshsize_yoke"] = (
+                min(Hsy, Hs / 2) / 4 / Kmesh_fineness
+            )
+            FEMM_dict["mesh"][label]["elementsize_yoke"] = (
+                min(Hsy, Hs / 2) / 4 / Kmesh_fineness
+            )
+        else:
+            # rotor slot region mesh and segments max element size parameter
+            if isinstance(lam, (LamSlotMag, LamHole)):
+                FEMM_dict["mesh"][label]["meshsize_slot"] = Hsy / 4 / Kmesh_fineness
+                FEMM_dict["mesh"][label]["elementsize_slot"] = Hsy / 4 / Kmesh_fineness
+            else:
+                FEMM_dict["mesh"][label]["meshsize_slot"] = Hstot / 8 / Kmesh_fineness
+                FEMM_dict["mesh"][label]["elementsize_slot"] = (
+                    Hstot / 8 / Kmesh_fineness
+                )
+            # rotor yoke region mesh and segments max element size parameter
+            FEMM_dict["mesh"][label]["meshsize_yoke"] = Hsy / 4 / Kmesh_fineness
+            FEMM_dict["mesh"][label]["elementsize_yoke"] = Hsy / 4 / Kmesh_fineness
+        # Wedge mesh
+        FEMM_dict["mesh"][label]["meshsize_wedge"] = Hstot / 20 / Kmesh_fineness
 
-    # stator yoke region mesh and segments max element size parameter
-    FEMM_dict["meshsize_yokeS"] = min(Hsy, Hs / 2) / 4 / Kmesh_fineness
-    FEMM_dict["elementsize_yokeS"] = min(Hsy, Hs / 2) / 4 / Kmesh_fineness
+        # mesh parameter for stator and rotor slot region
+        if type_calc_leakage == 1:
+            FEMM_dict["mesh"][label]["meshsize_slot"] = Hstot / 50
 
-    # rotor slot region mesh and segments max element size parameter
-    if type(machine.rotor) == LamSlotMag or type(machine.rotor) == LamHole:
-        FEMM_dict["meshsize_slotR"] = Hry / 4 / Kmesh_fineness
-        FEMM_dict["elementsize_slotR"] = Hry / 4 / Kmesh_fineness
-    else:
-        FEMM_dict["meshsize_slotR"] = Hrtot / 8 / Kmesh_fineness
-        FEMM_dict["elementsize_slotR"] = Hrtot / 8 / Kmesh_fineness
-
-    # rotor yoke region mesh and segments max element size parameter
-    FEMM_dict["meshsize_yokeR"] = Hry / 4 / Kmesh_fineness
-    FEMM_dict["elementsize_yokeR"] = Hry / 4 / Kmesh_fineness
+        # magnet region mesh and segments max element size parameter
+        if isinstance(lam, LamSlotMag):
+            Hmag = lam.slot.comp_height_active()
+            FEMM_dict["mesh"][label]["meshsize_magnet"] = Hmag / 4 / Kmesh_fineness
+            FEMM_dict["mesh"][label]["elementsize_magnet"] = Hmag / 4 / Kmesh_fineness
+        elif isinstance(lam, LamHole):
+            Hmag = lam.hole[0].comp_height()
+            FEMM_dict["mesh"][label]["meshsize_magnet"] = Hmag / 4 / Kmesh_fineness
+            FEMM_dict["mesh"][label]["elementsize_magnet"] = Hmag / 4 / Kmesh_fineness
+        else:
+            FEMM_dict["mesh"][label]["meshsize_magnet"] = None
 
     # airgap region mesh and segments max element size parameter
+    Wgap_mec = machine.comp_width_airgap_mec()
     if isinstance(machine, MachineSIPMSM):
-        FEMM_dict["meshsize_airgap"] = Wgap_mec / 10 / Kmesh_fineness
-        FEMM_dict["elementsize_airgap"] = Wgap_mec / 10 / Kmesh_fineness
+        FEMM_dict["mesh"]["meshsize_airgap"] = Wgap_mec / 10 / Kmesh_fineness
+        FEMM_dict["mesh"]["elementsize_airgap"] = Wgap_mec / 10 / Kmesh_fineness
     else:
-        FEMM_dict["meshsize_airgap"] = Wgap_mec / 3 / Kmesh_fineness
-        FEMM_dict["elementsize_airgap"] = Wgap_mec / 3 / Kmesh_fineness
-
-    # stator magnet region mesh and segments max element size parameter
-    if type(machine.stator) == LamSlotMag:
-        Hmag = machine.stator.slot.comp_height_active()
-        FEMM_dict["meshsize_magnetS"] = Hmag / 4 / Kmesh_fineness
-        FEMM_dict["elementsize_magnetS"] = Hmag / 4 / Kmesh_fineness
-    else:
-        FEMM_dict["meshsize_magnetS"] = None
-
-    # rotor magnet region mesh and segments max element size parameter
-    if type(machine.rotor) == LamSlotMag:
-        Hmag = machine.rotor.slot.comp_height_active()
-        FEMM_dict["meshsize_magnetR"] = Hmag / 4 / Kmesh_fineness
-        FEMM_dict["elementsize_magnetR"] = Hmag / 4 / Kmesh_fineness
-    elif type(machine.rotor) == LamHole:
-        Hmag = machine.rotor.hole[0].comp_height()
-        FEMM_dict["meshsize_magnetR"] = Hmag / 4 / Kmesh_fineness
-        FEMM_dict["elementsize_magnetR"] = Hmag / 4 / Kmesh_fineness
-    else:
-        FEMM_dict["meshsize_magnetR"] = None
+        FEMM_dict["mesh"]["meshsize_airgap"] = Wgap_mec / 3 / Kmesh_fineness
+        FEMM_dict["mesh"]["elementsize_airgap"] = Wgap_mec / 3 / Kmesh_fineness
 
     # mesh parameter for basic air regions (ventilation ducts etc)
-    FEMM_dict["meshsize_air"] = Hry / 4 / Kmesh_fineness
-    FEMM_dict["meshsize_wedge"] = Hstot / 20 / Kmesh_fineness
+    Hry = machine.get_lam_by_label(ROTOR_LAB).comp_height_yoke()
+    FEMM_dict["mesh"]["meshsize_air"] = Hry / 4 / Kmesh_fineness
 
-    # mesh parameter for stator and rotor slot region
-    if type_calc_leakage == 1:
-        FEMM_dict["is_close_model"] = 1
-        FEMM_dict["meshsize_slotS"] = Hstot / 50
-        FEMM_dict["meshsize_slotR"] = Hrtot / 50
-
-    # Set groups
+    # Set groups (to select area by type)
     FEMM_dict["groups"] = dict()
     for grp in FEMM_GROUPS:
         FEMM_dict["groups"][grp] = FEMM_GROUPS[grp]["ID"]

--- a/pyleecan/Functions/FEMM/comp_FEMM_dict.py
+++ b/pyleecan/Functions/FEMM/comp_FEMM_dict.py
@@ -132,4 +132,8 @@ def comp_FEMM_dict(machine, Kgeo_fineness, Kmesh_fineness, type_calc_leakage=0):
     for grp in FEMM_GROUPS:
         FEMM_dict["groups"][grp] = FEMM_GROUPS[grp]["ID"]
 
+    # Init empty list
+    FEMM_dict["materials"] = list()
+    FEMM_dict["circuits"] = list()
+
     return FEMM_dict

--- a/pyleecan/Functions/FEMM/create_FEMM_materials.py
+++ b/pyleecan/Functions/FEMM/create_FEMM_materials.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from numpy import exp, pi
-
-from ...Functions.FEMM.create_FEMM_bar import create_FEMM_bar
 from ...Functions.FEMM.create_FEMM_circuit_material import create_FEMM_circuit_material
 from ...Functions.FEMM.create_FEMM_magnet import create_FEMM_magnet
 from ...Functions.labels import (
@@ -23,13 +18,14 @@ from ...Functions.labels import (
     get_obj_from_label,
     decode_label,
 )
-from ...Functions.FEMM import LAM_MAT_NAME, AIRGAP_MAT_NAME
+from ...Functions.FEMM import LAM_MAT_NAME
 
 
 def create_FEMM_materials(
     femm,
     machine,
     surf_list,
+    FEMM_dict,
     Is,
     Ir,
     is_mmfs,
@@ -49,6 +45,8 @@ def create_FEMM_materials(
         the machine to simulate
     surf_list : list
         List of surface of the machine
+    FEMM_dict : dict
+        dictionary containing the main parameters of FEMM
     Is : ndarray
         Stator current matrix [A]
     Ir : ndarray
@@ -68,8 +66,8 @@ def create_FEMM_materials(
 
     Returns
     -------
-    Tuple: dict, list
-        Dictionary of properties and list containing the name of the circuits created
+    prop_dict, FEMM_dict : (dict, dict)
+        Dictionary of properties and dictionary containing the main parameters of FEMM
     """
 
     prop_dict = dict()  # Initialisation of the dictionary to return
@@ -77,8 +75,8 @@ def create_FEMM_materials(
     rotor = machine.rotor
     stator = machine.stator
 
-    materials = list()
-    circuits = list()
+    materials = FEMM_dict["materials"]
+    circuits = FEMM_dict["circuits"]
     # Starting creation of properties for each surface of the machine
     for surf in surf_list:
         label_dict = decode_label(surf.label)
@@ -182,4 +180,7 @@ def create_FEMM_materials(
             prop_dict[label_dict["full"]] = "<No Mesh>"
         else:
             raise Exception("Unknown label " + label_dict["full"])
-    return prop_dict, materials, circuits
+
+    FEMM_dict["materials"] = materials
+    FEMM_dict["circuits"] = circuits
+    return prop_dict, FEMM_dict

--- a/pyleecan/Functions/FEMM/draw_FEMM.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM.py
@@ -114,7 +114,9 @@ def draw_FEMM(
     # femm.main_minimize()
 
     # defining the problem
-    femm.mi_probdef(0, "meters", FEMM_dict["pbtype"], FEMM_dict["precision"])
+    femm.mi_probdef(
+        0, "meters", FEMM_dict["simu"]["pbtype"], FEMM_dict["simu"]["precision"]
+    )
 
     # Modifiy the machine to match the conditions
     machine_edit = machine.copy()
@@ -208,15 +210,15 @@ def draw_FEMM(
     # Define simulation parameters
     # femm.mi_zoomnatural()  # Zoom out
     femm.mi_probdef(
-        FEMM_dict["freqpb"],
+        FEMM_dict["simu"]["freqpb"],
         "meters",
-        FEMM_dict["pbtype"],
-        FEMM_dict["precision"],
-        FEMM_dict["Lfemm"],
-        FEMM_dict["minangle"],
-        FEMM_dict["acsolver"],
+        FEMM_dict["simu"]["pbtype"],
+        FEMM_dict["simu"]["precision"],
+        FEMM_dict["simu"]["Lfemm"],
+        FEMM_dict["simu"]["minangle"],
+        FEMM_dict["simu"]["acsolver"],
     )
-    femm.mi_smartmesh(FEMM_dict["smart_mesh"])
+    femm.mi_smartmesh(FEMM_dict["mesh"]["smart_mesh"])
     if path_save is not None:
         output.get_logger().debug("Saving FEMM file at: " + path_save)
         femm.mi_saveas(path_save)  # Save

--- a/pyleecan/Functions/FEMM/draw_FEMM.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM.py
@@ -126,9 +126,13 @@ def draw_FEMM(
         machine_edit.stator = Lamination(init_dict=lam_dict)
     # Remove ventilations
     if is_remove_ventR:
-        machine_edit.rotor.axial_vent = list()
+        for lam in machine_edit.get_lam_list(is_int_to_ext=True):
+            if not lam.is_stator:
+                lam.axial_vent = list()
     if is_remove_ventS:
-        machine_edit.stator.axial_vent = list()
+        for lam in machine_edit.get_lam_list(is_int_to_ext=True):
+            if lam.is_stator:
+                lam.axial_vent = list()
 
     # Lamination list organized from interior to exterior
     lam_list = machine_edit.get_lam_list(is_int_to_ext=True)

--- a/pyleecan/Functions/FEMM/draw_FEMM_lamination.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM_lamination.py
@@ -91,7 +91,9 @@ def draw_FEMM_lamination(
         for BC in lam_dxf.BC_list:
             if BC[1] is True:  # Select Arc
                 femm.mi_selectarcsegment(BC[0].real, BC[0].imag)
-                femm.mi_setarcsegmentprop(FEMM_dict["arcspan"], BC[2], False, None)
+                femm.mi_setarcsegmentprop(
+                    FEMM_dict["mesh"]["arcspan"], BC[2], False, None
+                )
             else:  # Select Line
                 femm.mi_selectsegment(BC[0].real, BC[0].imag)
                 femm.mi_setsegmentprop(BC[2], None, None, False, None)

--- a/pyleecan/Functions/FEMM/draw_FEMM_lamination.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM_lamination.py
@@ -1,21 +1,67 @@
 from ...Functions.FEMM.draw_FEMM_surfaces import draw_FEMM_surfaces
 
 
-def draw_FEMM_lamination(lam, sym, femm, transform_list=list(), lam_dxf=None):
+def draw_FEMM_lamination(
+    machine,
+    lam,
+    sym,
+    femm,
+    FEMM_dict,
+    transform_list,
+    lam_dxf,
+    BC_dict,
+    Is,
+    Ir,
+    is_mmfs=True,
+    is_mmfr=True,
+    type_BH_stator=0,
+    type_BH_rotor=0,
+):
     """Draw a Lamination in FEMM
 
+    Parameters
+    ----------
+    machine : Machine
+        Machine object to draw
+    lam : Lamination
+        Lamination object to draw
+    sym : int
+        the symmetry applied on the stator and the rotor (take into account antiperiodicity)
+    femm : FEMMHandler
+        client to send command to a FEMM instance
+    FEMM_dict : dict
+        dictionary containing the main parameters of FEMM
+    transform_list : list
+        List of transfromation to apply on the surfaces
     lam_dxf : DXFImport
-        To use a dxf version of the rotor instead of build_geometry
+        To use a dxf version of the Lamination instead of build_geometry
+    BC_dict : dict
+        Boundary condition dict ([line label] = BC name)
+    Is : ndarray
+        Stator current matrix [A]
+    Ir : ndarray
+        Rotor current matrix [A]
+    is_mmfs : bool
+        1 to compute the stator magnetomotive force/stator magnetic field
+    is_mmfr : bool
+        1 to compute the rotor magnetomotive force / rotor magnetic field
+    type_BH_stator: int
+        2 Infinite permeability, 1 to use linear B(H) curve according to mur_lin, 0 to use the B(H) curve
+    type_BH_rotor: int
+        2 Infinite permeability, 1 to use linear B(H) curve according to mur_lin, 0 to use the B(H) curve
+
+    Returns
+    -------
+    FEMM_dict : dict
+        dictionary containing the main parameters of FEMM
     """
 
-    surf_list = list()
-
-    # adding Both laminations surfaces (or import from DXF)
+    # Adding lamination surfaces (or import from DXF)
     if lam_dxf is not None:
         femm.mi_readdxf(lam_dxf.file_path)
-        surf_list.extend(lam_dxf.get_surfaces())
+        surf_list = lam_dxf.get_surfaces()
     else:
-        surf_list.extend(lam.build_geometry(sym=sym, is_circular_radius=True))
+        surf_list = lam.build_geometry(sym=sym, is_circular_radius=True)
 
     # Applying user defined modifications
     for transform in transform_list:
@@ -25,7 +71,30 @@ def draw_FEMM_lamination(lam, sym, femm, transform_list=list(), lam_dxf=None):
             elif transform["label"] in surf.label and transform["type"] == "translate":
                 surf.translate(transform["value"])
 
-    # Draw all the surfaces
-    FEMM_dict = draw_FEMM_surfaces(surf_list, FEMM_dict)
+    # Draw all the lamination related surfaces
+    FEMM_dict = draw_FEMM_surfaces(
+        femm,
+        machine,
+        surf_list,
+        FEMM_dict,
+        BC_dict,
+        Is,
+        Ir,
+        is_mmfs,
+        is_mmfr,
+        type_BH_stator,
+        type_BH_rotor,
+    )
+
+    # Apply BC for DXF import
+    if lam_dxf is not None:
+        for BC in lam_dxf.BC_list:
+            if BC[1] is True:  # Select Arc
+                femm.mi_selectarcsegment(BC[0].real, BC[0].imag)
+                femm.mi_setarcsegmentprop(FEMM_dict["arcspan"], BC[2], False, None)
+            else:  # Select Line
+                femm.mi_selectsegment(BC[0].real, BC[0].imag)
+                femm.mi_setsegmentprop(BC[2], None, None, False, None)
+            femm.mi_clearselected()
 
     return FEMM_dict

--- a/pyleecan/Functions/FEMM/draw_FEMM_lamination.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM_lamination.py
@@ -1,0 +1,31 @@
+from ...Functions.FEMM.draw_FEMM_surfaces import draw_FEMM_surfaces
+
+
+def draw_FEMM_lamination(lam, sym, femm, transform_list=list(), lam_dxf=None):
+    """Draw a Lamination in FEMM
+
+    lam_dxf : DXFImport
+        To use a dxf version of the rotor instead of build_geometry
+    """
+
+    surf_list = list()
+
+    # adding Both laminations surfaces (or import from DXF)
+    if lam_dxf is not None:
+        femm.mi_readdxf(lam_dxf.file_path)
+        surf_list.extend(lam_dxf.get_surfaces())
+    else:
+        surf_list.extend(lam.build_geometry(sym=sym, is_circular_radius=True))
+
+    # Applying user defined modifications
+    for transform in transform_list:
+        for surf in surf_list:
+            if transform["label"] in surf.label and transform["type"] == "rotate":
+                surf.rotate(transform["value"])
+            elif transform["label"] in surf.label and transform["type"] == "translate":
+                surf.translate(transform["value"])
+
+    # Draw all the surfaces
+    FEMM_dict = draw_FEMM_surfaces(surf_list, FEMM_dict)
+
+    return FEMM_dict

--- a/pyleecan/Functions/FEMM/draw_FEMM_surfaces.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM_surfaces.py
@@ -1,0 +1,35 @@
+def draw_FEMM_surfaces():
+    """Draw a list of surfaces in pyleecan"""
+    # Creation of all the materials and circuit in FEMM
+    prop_dict, materials, circuits = create_FEMM_materials(
+        femm,
+        machine,
+        surf_list,
+        Is,
+        Ir,
+        is_mmfs,
+        is_mmfr,
+        type_BH_stator,
+        type_BH_rotor,
+        is_eddies,
+        j_t0=0,
+    )
+
+    # Draw and assign all the surfaces of the machine
+    for surf in surf_list:
+        label = surf.label
+        # Get the correct element size and group according to the label
+        surf.draw_FEMM(
+            femm=femm,
+            nodeprop="None",
+            maxseg=FEMM_dict["arcspan"],  # max span of arc element in degrees
+            FEMM_dict=FEMM_dict,
+            hide=False,
+            BC_dict=BC_dict,
+        )
+        assign_FEMM_surface(femm, surf, prop_dict[label], FEMM_dict, machine)
+
+    FEMM_dict["materials"] = materials
+    FEMM_dict["circuits"] = circuits
+
+    return FEMM_dict

--- a/pyleecan/Functions/FEMM/draw_FEMM_surfaces.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM_surfaces.py
@@ -71,7 +71,7 @@ def draw_FEMM_surfaces(
         surf.draw_FEMM(
             femm=femm,
             nodeprop="None",
-            maxseg=FEMM_dict["arcspan"],  # max span of arc element in degrees
+            maxseg=FEMM_dict["mesh"]["arcspan"],  # max span of arc element in degrees
             FEMM_dict=FEMM_dict,
             hide=False,
             BC_dict=BC_dict,

--- a/pyleecan/Functions/FEMM/draw_FEMM_surfaces.py
+++ b/pyleecan/Functions/FEMM/draw_FEMM_surfaces.py
@@ -1,10 +1,59 @@
-def draw_FEMM_surfaces():
-    """Draw a list of surfaces in pyleecan"""
+from ...Functions.FEMM import is_eddies
+from ...Functions.FEMM.create_FEMM_materials import create_FEMM_materials
+from ...Functions.FEMM.assign_FEMM_surface import assign_FEMM_surface
+
+
+def draw_FEMM_surfaces(
+    femm,
+    machine,
+    surf_list,
+    FEMM_dict,
+    BC_dict,
+    Is,
+    Ir,
+    is_mmfs,
+    is_mmfr,
+    type_BH_stator,
+    type_BH_rotor,
+):
+    """Draw a list of surfaces in FEMM
+
+    Parameters
+    ----------
+    femm : FEMMHandler
+        client to send command to a FEMM instance
+    machine : Machine
+        Machine object to draw
+    surf_list : list
+        List of surfaces to draw
+    FEMM_dict : dict
+        dictionary containing the main parameters of FEMM
+    BC_dict : dict
+        Boundary condition dict ([line label] = BC name)
+    Is : ndarray
+        Stator current matrix [A]
+    Ir : ndarray
+        Rotor current matrix [A]
+    is_mmfs : bool
+        1 to compute the stator magnetomotive force/stator magnetic field
+    is_mmfr : bool
+        1 to compute the rotor magnetomotive force / rotor magnetic field
+    type_BH_stator: int
+        2 Infinite permeability, 1 to use linear B(H) curve according to mur_lin, 0 to use the B(H) curve
+    type_BH_rotor: int
+        2 Infinite permeability, 1 to use linear B(H) curve according to mur_lin, 0 to use the B(H) curve
+
+    Returns
+    -------
+    FEMM_dict : dict
+        dictionary containing the main parameters of FEMM
+    """
     # Creation of all the materials and circuit in FEMM
-    prop_dict, materials, circuits = create_FEMM_materials(
+    prop_dict, FEMM_dict = create_FEMM_materials(
         femm,
         machine,
         surf_list,
+        FEMM_dict,
         Is,
         Ir,
         is_mmfs,
@@ -28,8 +77,5 @@ def draw_FEMM_surfaces():
             BC_dict=BC_dict,
         )
         assign_FEMM_surface(femm, surf, prop_dict[label], FEMM_dict, machine)
-
-    FEMM_dict["materials"] = materials
-    FEMM_dict["circuits"] = circuits
 
     return FEMM_dict

--- a/pyleecan/Functions/FEMM/get_mesh_param.py
+++ b/pyleecan/Functions/FEMM/get_mesh_param.py
@@ -35,75 +35,72 @@ def get_mesh_param(label_dict, FEMM_dict):
     mesh_dict = dict()
 
     # Default automesh except airgap
-    mesh_dict["automesh"] = FEMM_dict["automesh"]
+    mesh_dict["automesh"] = FEMM_dict["mesh"]["automesh"]
+    # Get the mesh sizes related to the lamination label
+    if label_dict["lam_label"] != "None":
+        lam_mesh_dict = FEMM_dict["mesh"][label_dict["lam_label"]]
+    else:
+        lam_mesh_dict = None
+    maxelementsize = FEMM_dict["mesh"]["maxelementsize"]
+    meshsize_air = FEMM_dict["mesh"]["meshsize_air"]
 
-    if LAM_LAB in label_dict["surf_type"] and STATOR_LAB in label_dict["lam_type"]:
-        # Stator Lamination
+    # Lamination
+    if LAM_LAB in label_dict["surf_type"]:
         if BORE_LAB in label_dict["surf_type"]:
-            mesh_dict["element_size"] = FEMM_dict["elementsize_slotS"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_slotS"]
+            mesh_dict["element_size"] = lam_mesh_dict["elementsize_slot"]
+            mesh_dict["meshsize"] = lam_mesh_dict["meshsize_slot"]
         else:  # Yoke or other lines
-            mesh_dict["element_size"] = FEMM_dict["elementsize_yokeS"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_yokeS"]
-        mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SC"]
-    elif LAM_LAB in label_dict["surf_type"] and ROTOR_LAB in label_dict["lam_type"]:
-        # Rotor Lamination
-        if BORE_LAB in label_dict["surf_type"]:
-            mesh_dict["element_size"] = FEMM_dict["elementsize_slotR"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_slotR"]
-        else:  # Yoke or other lines
-            mesh_dict["element_size"] = FEMM_dict["elementsize_yokeR"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_yokeR"]
-        mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RC"]
-    elif VENT_LAB in label_dict["surf_type"]:  # Ventilation
-        mesh_dict["element_size"] = FEMM_dict["maxelementsize"]
-        mesh_dict["meshsize"] = FEMM_dict["meshsize_air"]
+            mesh_dict["element_size"] = lam_mesh_dict["elementsize_yoke"]
+            mesh_dict["meshsize"] = lam_mesh_dict["meshsize_yoke"]
+        if STATOR_LAB in label_dict["lam_type"]:
+            mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SC"]
+        elif ROTOR_LAB in label_dict["lam_type"]:
+            mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RC"]
+    # Ventilation
+    elif VENT_LAB in label_dict["surf_type"]:
+        mesh_dict["element_size"] = maxelementsize
+        mesh_dict["meshsize"] = meshsize_air
         if STATOR_LAB in label_dict["lam_type"]:
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SV"]
         else:  # if the Ventilation is on the Rotor
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RV"]
+    # Hole Air zone
     elif HOLEV_LAB in label_dict["surf_type"]:
-        mesh_dict["element_size"] = FEMM_dict["maxelementsize"]
-        mesh_dict["meshsize"] = FEMM_dict["meshsize_air"]
+        mesh_dict["element_size"] = maxelementsize
+        mesh_dict["meshsize"] = meshsize_air
         if STATOR_LAB in label_dict["lam_type"]:  # if the Hole is on the Stator
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SH"]
         else:  # if the Hole is on the Rotor
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RH"]
+    # Magnet or HoleMagnet
     elif HOLEM_LAB in label_dict["surf_type"] or MAG_LAB in label_dict["surf_type"]:
-        # Magnet or HoleMagnet
+        mesh_dict["element_size"] = lam_mesh_dict["elementsize_magnet"]
+        mesh_dict["meshsize"] = lam_mesh_dict["meshsize_magnet"]
         if STATOR_LAB in label_dict["lam_type"]:  # if the Magnet is on the Stator
-            mesh_dict["element_size"] = FEMM_dict["elementsize_magnetS"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_magnetS"]
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SM"]
         else:  # if the Magnet is on the Rotor
-            mesh_dict["element_size"] = FEMM_dict["elementsize_magnetR"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_magnetR"]
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RM"]
+    # Winding or Bar
     elif WIND_LAB in label_dict["surf_type"] or BAR_LAB in label_dict["surf_type"]:
-        # Winding
+        mesh_dict["element_size"] = lam_mesh_dict["elementsize_slot"]
+        mesh_dict["meshsize"] = lam_mesh_dict["meshsize_slot"]
         if STATOR_LAB in label_dict["lam_type"]:  # if the winding is on the Stator
-            mesh_dict["element_size"] = FEMM_dict["elementsize_slotS"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_slotS"]
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SW"]
         else:  # if the winding is on the Rotor
-            mesh_dict["element_size"] = FEMM_dict["elementsize_slotR"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_slotR"]
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RW"]
-    elif (
-        SOP_LAB in label_dict["surf_type"] or NOTCH_LAB in label_dict["surf_type"]
-    ):  # Slot opening or Notches
+    # Slot opening or Notches
+    elif SOP_LAB in label_dict["surf_type"] or NOTCH_LAB in label_dict["surf_type"]:
+        mesh_dict["element_size"] = lam_mesh_dict["elementsize_slot"]
+        mesh_dict["meshsize"] = lam_mesh_dict["meshsize_slot"]
         if STATOR_LAB in label_dict["lam_type"]:  # if the notch is on the Stator
-            mesh_dict["element_size"] = FEMM_dict["elementsize_slotS"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_slotS"]
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SN"]
         else:  # if the notch is on the Rotor
-            mesh_dict["element_size"] = FEMM_dict["elementsize_slotR"]
-            mesh_dict["meshsize"] = FEMM_dict["meshsize_slotR"]
             mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RN"]
+    # Sliding Band / Airgap
     elif SLID_LAB in label_dict["surf_type"] or AIRGAP_LAB in label_dict["surf_type"]:
-        mesh_dict["automesh"] = FEMM_dict["automesh_airgap"]
-        mesh_dict["element_size"] = FEMM_dict["elementsize_airgap"]
-        mesh_dict["meshsize"] = FEMM_dict["meshsize_airgap"]
+        mesh_dict["automesh"] = FEMM_dict["mesh"]["automesh_airgap"]
+        mesh_dict["element_size"] = FEMM_dict["mesh"]["elementsize_airgap"]
+        mesh_dict["meshsize"] = FEMM_dict["mesh"]["meshsize_airgap"]
         mesh_dict["group"] = FEMM_dict["groups"]["GROUP_AG"]
     elif NO_MESH_LAB in label_dict["surf_type"]:
         mesh_dict["automesh"] = 0
@@ -112,11 +109,11 @@ def get_mesh_param(label_dict, FEMM_dict):
         mesh_dict["group"] = FEMM_dict["groups"]["GROUP_AG"]
     elif STATOR_LAB in label_dict["lam_type"]:
         # if label don't belong to any of the other groups
-        mesh_dict["element_size"] = FEMM_dict["maxelementsize"]
+        mesh_dict["element_size"] = maxelementsize
         mesh_dict["group"] = FEMM_dict["groups"]["GROUP_SC"]
     elif ROTOR_LAB in label_dict["lam_type"]:
         # if label don't belong to any of the other groups
-        mesh_dict["element_size"] = FEMM_dict["maxelementsize"]
+        mesh_dict["element_size"] = maxelementsize
         mesh_dict["group"] = FEMM_dict["groups"]["GROUP_RC"]
     else:
         raise Exception(

--- a/pyleecan/GUI/Dialog/DMachineSetup/SPreview/WMachineTable/WMachineTable.py
+++ b/pyleecan/GUI/Dialog/DMachineSetup/SPreview/WMachineTable/WMachineTable.py
@@ -19,9 +19,7 @@ from ......Functions.Plot.set_plot_gui_icon import set_plot_gui_icon
 from ......GUI.Dialog.DMachineSetup.SPreview.WMachineTable.Ui_WMachineTable import (
     Ui_WMachineTable,
 )
-from ......Methods.Simulation.MagElmer import (
-    MagElmer_BP_dict,
-)
+from ......Methods.Simulation.MagElmer import MagElmer_BP_dict
 
 try:
     from ......Functions.GMSH.draw_GMSH import draw_GMSH
@@ -101,7 +99,7 @@ class WMachineTable(Ui_WMachineTable, QWidget):
 
     def plot_mmf(self):
         """Plot the unit mmf of the stator"""
-       try:
+        try:
             if self.machine is not None:
                 self.machine.stator.plot_mmf_unit(is_create_appli=False)
                 set_plot_gui_icon()
@@ -109,7 +107,7 @@ class WMachineTable(Ui_WMachineTable, QWidget):
             err_msg = "Error while plotting Stator mmf unit:\n" + str(e)
             getLogger(GUI_LOG_NAME).error(err_msg)
             QMessageBox().critical(self, self.tr("Error"), err_msg)
-                
+
     def plot_machine(self):
         """Plot the machine"""
         if self.machine is not None:
@@ -179,9 +177,7 @@ class WMachineTable(Ui_WMachineTable, QWidget):
             )
             getLogger(GUI_LOG_NAME).error(err_msg)
             QMessageBox().critical(
-                self,
-                self.tr("Error"),
-                self.tr(err_msg),
+                self, self.tr("Error"), self.tr(err_msg),
             )
         femm.closefemm()
 
@@ -217,9 +213,7 @@ class WMachineTable(Ui_WMachineTable, QWidget):
             )
             getLogger(GUI_LOG_NAME).error(err_msg)
             QMessageBox().critical(
-                self,
-                self.tr("Error"),
-                self.tr(err_msg),
+                self, self.tr("Error"), self.tr(err_msg),
             )
 
     def draw_GMSH_3D(self):
@@ -244,9 +238,7 @@ class WMachineTable(Ui_WMachineTable, QWidget):
             )
             getLogger(GUI_LOG_NAME).error(err_msg)
             QMessageBox().critical(
-                self,
-                self.tr("Error"),
-                self.tr(err_msg),
+                self, self.tr("Error"), self.tr(err_msg),
             )
 
     def get_save_path(self, ext=".fem", file_type="FEMM (*.fem)"):

--- a/pyleecan/GUI/Dxf/DXF_Slot.py
+++ b/pyleecan/GUI/Dxf/DXF_Slot.py
@@ -448,22 +448,6 @@ class DXF_Slot(Ui_DXF_Slot, QDialog):
             )
             return None
 
-        # Create the Slot object
-        slot = SlotUD(line_list=curve_list)
-        slot.type_line_wind = self.c_type_line.currentIndex()
-        begin_id = self.si_wind_begin_index.value()
-        end_id = self.si_wind_end_index.value()
-        if (
-            begin_id < len(curve_list)
-            and end_id < len(curve_list)
-            and begin_id < end_id
-        ):
-            slot.wind_begin_index = begin_id
-            slot.wind_end_index = end_id
-        else:
-            slot.wind_begin_index = None
-            slot.wind_end_index = None
-
         # Rotation
         Z1 = curve_list[0].get_begin()
         Z2 = curve_list[-1].get_end()
@@ -482,7 +466,21 @@ class DXF_Slot(Ui_DXF_Slot, QDialog):
         if abs(Ze2 - Zend) > 1e-9:
             curve_list.append(Segment(begin=Zend, end=Ze2))
 
-        # Set metadata
+        # Create the Slot object
+        slot = SlotUD(line_list=curve_list)
+        slot.type_line_wind = self.c_type_line.currentIndex()
+        begin_id = self.si_wind_begin_index.value()
+        end_id = self.si_wind_end_index.value()
+        if (
+            begin_id < len(curve_list)
+            and end_id < len(curve_list)
+            # and begin_id < end_id
+        ):
+            slot.wind_begin_index = begin_id
+            slot.wind_end_index = end_id
+        else:
+            slot.wind_begin_index = None
+            slot.wind_end_index = None
         slot.Zs = self.si_Zs.value()
 
         return slot

--- a/pyleecan/Methods/Machine/LamSlot/get_surfaces_closing.py
+++ b/pyleecan/Methods/Machine/LamSlot/get_surfaces_closing.py
@@ -1,5 +1,6 @@
 from numpy import pi
 from ....Functions.labels import update_RTS_index
+from ....Classes.Lamination import Lamination
 
 
 def get_surfaces_closing(self, sym=1):
@@ -18,10 +19,11 @@ def get_surfaces_closing(self, sym=1):
         List of the closing surfaces
     """
 
+    # Get notches closing surfaces
+    close_list = Lamination.get_surfaces_closing(sym=sym)
     if not hasattr(self.slot, "get_surface_opening"):
-        return list()
-    else:
-        close_list = list()
+        return close_list
+    else:  # Get slot closing surfaces
         slot_pitch = 2 * pi / self.slot.Zs
         # for slot to draw
         for ii in range(self.slot.Zs // sym):

--- a/pyleecan/Methods/Machine/LamSlot/get_surfaces_closing.py
+++ b/pyleecan/Methods/Machine/LamSlot/get_surfaces_closing.py
@@ -20,7 +20,7 @@ def get_surfaces_closing(self, sym=1):
     """
 
     # Get notches closing surfaces
-    close_list = Lamination.get_surfaces_closing(sym=sym)
+    close_list = Lamination.get_surfaces_closing(self=self, sym=sym)
     if not hasattr(self.slot, "get_surface_opening"):
         return close_list
     else:  # Get slot closing surfaces

--- a/pyleecan/Methods/Machine/LamSquirrelCage/plot.py
+++ b/pyleecan/Methods/Machine/LamSquirrelCage/plot.py
@@ -57,6 +57,7 @@ def plot(
     LamSlotWind.plot(
         self,
         fig=fig,
+        ax=axes,
         is_lam_only=is_lam_only,
         sym=sym,
         alpha=alpha,
@@ -66,7 +67,7 @@ def plot(
     )
 
     # init figure again to get updated label_leg and patch_leg
-    (fig, axes, patch_leg, label_leg) = init_fig(fig)
+    (fig, axes, patch_leg, label_leg) = init_fig(fig, ax=axes)
 
     # setup the patch of the short circuit ring if needed
     patches = list()

--- a/pyleecan/Methods/Machine/Lamination/get_surfaces_closing.py
+++ b/pyleecan/Methods/Machine/Lamination/get_surfaces_closing.py
@@ -14,4 +14,4 @@ def get_surfaces_closing(self, sym=1):
         List of the closing surfaces
     """
 
-    return list()
+    return self.get_notches_surf(sym=sym)

--- a/pyleecan/Methods/Machine/Machine/get_lam_by_label.py
+++ b/pyleecan/Methods/Machine/Machine/get_lam_by_label.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ....Functions.labels import STATOR_LAB, ROTOR_LAB, ROTOR_LAB_S, STATOR_LAB_S
 
 

--- a/pyleecan/Methods/Machine/Machine/get_lam_list.py
+++ b/pyleecan/Methods/Machine/Machine/get_lam_list.py
@@ -24,14 +24,13 @@ def get_lam_list(self, is_int_to_ext=True, key=None):
     lam_list = []
     if hasattr(self, "lam_list"):
         lam_list = self.lam_list
-        # Sort by Rint by assuming the lamination are not colliding
     else:
         if hasattr(self, "stator"):
             lam_list.append(self.stator)
         if hasattr(self, "rotor"):
             lam_list.append(self.rotor)
 
-    # Sort all laminations according to Rint
+    # Sort all laminations according to Rint by assuming the lamination are not colliding
     if is_int_to_ext is not None:
         lam_list = sorted(lam_list, key=lambda x: x.Rint, reverse=not is_int_to_ext)
 


### PR DESCRIPTION
Hello all,

This PR reorganize the coupling with FEMM to prepare for future development:
- Before we called build_geometry on both rotor and stator to get the surf_list to draw and all the surfaces were drawn in a same loop. Now a dedicated method generate and draw the surface for each lamination (within a loop on get_lam_list). This will enable to take advantage of the symmetry of each lamination to speed-up the draw of the machine (for the full Prius we can draw only 1/8 of the rotor and 1/48 of the stator and copy rotate to generate each lamination separatly)
- The FEMM_dict was reorganized by sorting the parameters in two new key "simu" and "mesh". The "mesh" dict was also extended with a label for each lamination and the corresponding mesh element size. Which is another step towards N laminations in FEMM. 

Regarding the second point I'm wondering how we would handle groups for N laminations. Would it be better to have dedicated groups for each lamination or to gather all the rotor and stator in the same group even if it is shared on several laminations. Is it possible to set several group on a surface ?

Anyway all the tests are working so this PR can be merged
Best regards,
Pierre