### PR TITLE
Retrocompatibility

### DIFF
--- a/Tests/Functions/test_retrocompatibility.py
+++ b/Tests/Functions/test_retrocompatibility.py
@@ -113,7 +113,9 @@ def test_before_version():
     assert not is_before_version("1.2.3", "2.2.3")
     assert not is_before_version("1.2.3", "1.3.0")
     assert not is_before_version("1.2.3", "1.2.4")
+    assert not is_before_version("1.2.3", "1.2.3")
     assert not is_before_version("1.2.3", "1.2.3.2")
+    assert is_before_version("1.2.3.2", "1.2.3")
 
 
 if __name__ == "__main__":

--- a/Tests/Functions/test_retrocompatibility.py
+++ b/Tests/Functions/test_retrocompatibility.py
@@ -7,6 +7,7 @@ import pytest
 from numpy import array_equal
 from pyleecan.definitions import DATA_DIR
 from pyleecan.Functions.load import load
+from pyleecan.Functions.Load.retrocompatibility import is_before_version
 from Tests import TEST_DATA_DIR
 
 
@@ -102,6 +103,17 @@ def test_save_load_wind_retro(file_dict):
         ref.stator.winding.get_connection_mat(),
         old.stator.winding.get_connection_mat(),
     ), msg
+
+
+def test_before_version():
+    """Check that we can detect previous version"""
+    assert is_before_version("1.2.3", "1.2.1")
+    assert is_before_version("1.2.3", "1.1.3")
+    assert is_before_version("1.2.3", "0.2.3")
+    assert not is_before_version("1.2.3", "2.2.3")
+    assert not is_before_version("1.2.3", "1.3.0")
+    assert not is_before_version("1.2.3", "1.2.4")
+    assert not is_before_version("1.2.3", "1.2.3.2")
 
 
 if __name__ == "__main__":

--- a/pyleecan/Functions/Load/retrocompatibility.py
+++ b/pyleecan/Functions/Load/retrocompatibility.py
@@ -72,10 +72,10 @@ def _search_and_update(obj_dict, parent=None, parent_index=None, update_dict=Non
 
 
 ############################################
-# V 1.3.8 => 1.3.9
+# V 1.3.7 => 1.3.8
 # Introducing OP object (assume all is OPdq)
 ############################################
-OP_VERSION = "1.3.9"
+OP_VERSION = "1.3.8"
 
 
 def is_OP_dict(obj_dict):
@@ -88,13 +88,17 @@ def is_OP_dict(obj_dict):
 
 
 def convert_OP(obj_dict):
-    N0 = obj_dict.pop("N0")
-    Id = obj_dict.pop("Id_ref")
-    Iq = obj_dict.pop("Iq_ref")
-    Tem = obj_dict.pop("Tem_av_ref")
+    obj_dict_new = obj_dict.copy()
+    Class_obj = import_class("pyleecan.Classes", obj_dict_new["__class__"])
+    N0 = obj_dict_new.pop("N0")
+    Id = obj_dict_new.pop("Id_ref")
+    Iq = obj_dict_new.pop("Iq_ref")
+    Tem = obj_dict_new.pop("Tem_av_ref")
+    class_obj = Class_obj(init_dict=obj_dict_new)
     OPdq = import_class("pyleecan.Classes", "OPdq")
     OP = OPdq(N0=N0, Id_ref=Id, Iq_ref=Iq, Tem_av_ref=Tem)
-    return OP
+    class_obj.OP = OP
+    return class_obj
 
 
 ############################################

--- a/pyleecan/Functions/Load/retrocompatibility.py
+++ b/pyleecan/Functions/Load/retrocompatibility.py
@@ -260,6 +260,9 @@ def is_before_version(ref_version, check_version):
     is_before : bool
         True if check_version is before ref_version
     """
+    if ref_version == check_version:
+        return False
+
     ref_list = [int(val) for val in ref_version.split(".")]
     check_list = [int(val) for val in check_version.split(".")]
 
@@ -270,6 +273,10 @@ def is_before_version(ref_version, check_version):
             return True
         elif ref_list[ii] < check_list[ii]:
             return False
+
+    # Case 2.1.14.2 vs 2.1.14
+    if len(ref_list) > len(check_list):
+        return True
 
 
 def create_update_dict(file_version):


### PR DESCRIPTION
This branch improves the retrocompatibility:
- instantiate objects immediately when detecting a retro issue, instead of modifying the dict
- checking the version to avoid searching the whole object when it is not necessary