### PR TITLE
Improve setters and getters for ParamExplorer and Datakeepers

### DIFF
--- a/Tests/Methods/Simulation/test_VarParam_fct_save_load.py
+++ b/Tests/Methods/Simulation/test_VarParam_fct_save_load.py
@@ -1,0 +1,108 @@
+from os.path import join, isdir
+from os import mkdir, remove
+
+import numpy as np
+
+from pyleecan.Classes.OPdq import OPdq
+from pyleecan.Classes.Simu1 import Simu1
+from pyleecan.Classes.InputCurrent import InputCurrent
+from pyleecan.Classes.VarParam import VarParam
+from pyleecan.Classes.Simu1 import Simu1
+from pyleecan.Classes.DataKeeper import DataKeeper
+from pyleecan.Classes.ParamExplorerSet import ParamExplorerSet
+
+
+from pyleecan.Functions.load import load
+
+
+from pyleecan.definitions import DATA_DIR, RESULT_DIR
+
+
+def test_VarParam_fct_save_load():
+    """Test to check keeper, setter and getter functions defined as path containing
+    global variable <PARAM_DIR>"""
+
+    machine = load(join(DATA_DIR, "Machine", "Toyota_Prius.json"))
+
+    # First simulation creating femm file
+    simu = Simu1(name="test_VarParam_fct_save_load", machine=machine)
+
+    result_folder = join(RESULT_DIR, simu.name)
+    if not isdir(result_folder):
+        mkdir(result_folder)
+
+    # Create function files
+    keeper_path = join(result_folder, "keeper_fct.py")
+    with open(keeper_path, "w+") as keeper_file:
+        keeper_file.write("def keeper_fct(out):\n    return 1")
+
+    setter_path = join(result_folder, "setter_fct.py")
+    with open(setter_path, "w+") as setter_file:
+        setter_file.write("def setter_fct(out, val):\n    return None")
+
+    getter_path = join(result_folder, "getter_fct.py")
+    with open(getter_path, "w+") as getter_file:
+        getter_file.write("def getter_fct(out):\n    return 2")
+
+    # Initialization of the simulation starting point
+    simu.input = InputCurrent(
+        OP=OPdq(N0=1000, Id_ref=0, Iq_ref=0),
+        Nt_tot=8 * 10,
+        Na_tot=8 * 200,
+        is_periodicity_a=True,
+        is_periodicity_t=True,
+    )
+
+    # Generate parameter sweep
+    simu.var_simu = VarParam(
+        stop_if_error=True,
+        is_keep_all_output=True,
+        datakeeper_list=[
+            DataKeeper(
+                name="Dummy result",
+                symbol="res",
+                unit="-",
+                keeper="<RESULT_DIR>/" + simu.name + "/keeper_fct.py",
+                error_keeper="lambda simu: np.nan",
+            )
+        ],
+        paramexplorer_list=[
+            ParamExplorerSet(
+                name="Dummy variable",
+                symbol="X",
+                unit="-",
+                setter="<RESULT_DIR>/" + simu.name + "/setter_fct.py",
+                getter="<RESULT_DIR>/" + simu.name + "/getter_fct.py",
+                value=[ii for ii in range(2)],
+            )
+        ],
+        is_reuse_femm_file=False,
+        is_reuse_LUT=False,
+    )
+
+    out = simu.run()
+
+    out_h5_path = join(result_folder, simu.name + ".h5")
+
+    out.save(out_h5_path)
+
+    out_load = load(out_h5_path)
+
+    test = out.compare(out_load)
+
+    assert len(test) == 2
+    assert test[0] == "self.xoutput_dict.result"
+    assert test[1] == "self.xoutput_dict.result"
+
+    # Delete files
+    remove(keeper_path)
+    remove(setter_path)
+    remove(getter_path)
+    remove(out_h5_path)
+
+
+if __name__ == "__main__":
+
+    test_VarParam_fct_save_load()
+
+    print("Done")

--- a/pyleecan/Classes/Class_Dict.json
+++ b/pyleecan/Classes/Class_Dict.json
@@ -954,7 +954,8 @@
         "is_internal": false,
         "methods": [
             "as_dict",
-            "_set_result"
+            "_set_result",
+            "_set_keeper"
         ],
         "mother": "",
         "name": "DataKeeper",

--- a/pyleecan/Classes/DataKeeper.py
+++ b/pyleecan/Classes/DataKeeper.py
@@ -27,6 +27,11 @@ try:
 except ImportError as error:
     _set_result = error
 
+try:
+    from ..Methods.Simulation.DataKeeper._set_keeper import _set_keeper
+except ImportError as error:
+    _set_keeper = error
+
 
 from ntpath import basename
 from os.path import isfile
@@ -62,6 +67,17 @@ class DataKeeper(FrozenClass):
         )
     else:
         _set_result = _set_result
+    # cf Methods.Simulation.DataKeeper._set_keeper
+    if isinstance(_set_keeper, ImportError):
+        _set_keeper = property(
+            fget=lambda x: raise_(
+                ImportError(
+                    "Can't use DataKeeper method _set_keeper: " + str(_set_keeper)
+                )
+            )
+        )
+    else:
+        _set_keeper = _set_keeper
     # save and copy methods are available in all object
     save = save
     copy = copy
@@ -316,28 +332,6 @@ class DataKeeper(FrozenClass):
     def _get_keeper(self):
         """getter of keeper"""
         return self._keeper_func
-
-    def _set_keeper(self, value):
-        """setter of keeper"""
-        if value is None:
-            self._keeper_str = None
-            self._keeper_func = None
-        elif isinstance(value, str) and "lambda" in value:
-            self._keeper_str = value
-            self._keeper_func = eval(value)
-        elif isinstance(value, str) and isfile(value) and value[-3:] == ".py":
-            self._keeper_str = value
-            f = open(value, "r")
-            exec(f.read(), globals())
-            self._keeper_func = eval(basename(value[:-3]))
-        elif callable(value):
-            self._keeper_str = None
-            self._keeper_func = value
-        else:
-            raise CheckTypeError(
-                "For property keeper Expected function or str (path to python file or lambda), got: "
-                + str(type(value))
-            )
 
     keeper = property(
         fget=_get_keeper,

--- a/pyleecan/Functions/path_tools.py
+++ b/pyleecan/Functions/path_tools.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
-from os.path import isfile, join, normpath, abspath
 import re
+from os.path import isfile, join
 
 
 def importName(modulename, name, ignore_error=False):
@@ -8,7 +7,7 @@ def importName(modulename, name, ignore_error=False):
     try:
         module = __import__(modulename, globals(), locals(), [name])
         return vars(module)[name]
-    except:
+    except Exception:
         if ignore_error:
             return None
         else:
@@ -18,32 +17,34 @@ def importName(modulename, name, ignore_error=False):
             )
 
 
-def rel_file_path(file, wildcard):
+def rel_file_path(file_path, wildcard):
     """try to generate relative file path with given wildcard"""
     root_path = importName("..definitions", wildcard, ignore_error=True)
     if root_path:
         root_path = normpath(abspath(root_path))
-        file_ = normpath(abspath(file))
+        file_ = normpath(abspath(file_path))
         idx = len(root_path)
         # print(f"rel_file_path: {root_path}, <{wildcard}>")
         # print(f"file:          {file_[:idx]}")
         if file_[:idx].lower() == root_path.lower():
-            file = f"<{wildcard}>" + file_[idx:]
+            file_path = f"<{wildcard}>" + file_[idx:]
 
-    return file
+    return file_path
 
 
-def abs_file_path(file, is_check=True):
+def abs_file_path(file_path, is_check=True):
     """check a file path for a wildcard and replace it to get the abs path"""
-    if "<" in file and ">\\" in file:
-        wildcard = re.search(r"\<([A-Za-z0-9_]+)\>", file).group(1)
-        root_path = importName("..definitions", wildcard)
-        file = join(root_path, file.replace(f"<{wildcard}>\\", ""))
+    file_path = file_path.replace("\\", "/")
+    if "<" in file_path and ">" in file_path:
+        wildcard = re.search(r"\<([A-Za-z0-9_]+)\>", file_path).group(1)
+        root_path = importName("pyleecan.definitions", wildcard)
+        file_path = file_path.replace("<" + wildcard + ">/", "")
+        file_path = join(root_path, file_path).replace("\\", "/")
 
-    if not isfile(file) and is_check:
-        raise FileError("ERROR: The file doesn't exist " + file)
+    if not isfile(file_path) and is_check:
+        raise FileError("ERROR: The file doesn't exist " + file_path)
 
-    return file
+    return file_path
 
 
 class FileError(Exception):

--- a/pyleecan/Generator/ClassesRef/Simulation/DataKeeper.csv
+++ b/pyleecan/Generator/ClassesRef/Simulation/DataKeeper.csv
@@ -1,7 +1,7 @@
 Variable name,Unit,Description (EN),Size,Type,Default value,Minimum value,Maximum value,,Package,Inherit,Methods,Constant Name,Constant Value,Class description
 name,-,Data name,0,str,,,,,Simulation,,as_dict,VERSION,1,Class for defining data to keep on a multi-simulation
 symbol,-,Data symbol,,str,,,,,,,_set_result,,,
-unit,-,Data unit,,str,,,,,,,,,,
+unit,-,Data unit,,str,,,,,,,_set_keeper,,,
 keeper,-,Function that takes an Output in argument and return a value,,function,None,,,,,,,,,
 error_keeper,-,"Function that takes a Simulation in argument and returns a value, this attribute enables to handle errors and to put NaN values in the result matrices",,function,None,,,,,,,,,
 result,-,List containing datakeeper results for each simulation,,list,[],,,,,,,,,

--- a/pyleecan/Generator/__init__.py
+++ b/pyleecan/Generator/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 PYTHON_TYPE = ["float", "int", "str", "bool", "complex", "list", "dict", "tuple"]
 # Indentation according to PEP 8
 TAB = "    "
@@ -9,3 +7,5 @@ TAB4 = TAB + TAB + TAB + TAB
 TAB5 = TAB + TAB + TAB + TAB + TAB
 TAB6 = TAB + TAB + TAB + TAB + TAB + TAB
 TAB7 = TAB + TAB + TAB + TAB + TAB + TAB + TAB
+
+PYTHON_DEFAULT_ENCODING = "utf-8-sig"

--- a/pyleecan/Methods/Simulation/DataKeeper/_set_keeper.py
+++ b/pyleecan/Methods/Simulation/DataKeeper/_set_keeper.py
@@ -4,38 +4,39 @@ from ....Functions.path_tools import abs_file_path
 from ....Generator import PYTHON_DEFAULT_ENCODING
 
 
-def _set_getter(self, value):
-    """setter of getter"""
-    # Create the function if getter is defined as a string (e.g. simu.machine.rotor.slot.W0)
+def _set_keeper(self, value):
+    """setter of keeper"""
+    # Create the function if setter is defined as a string (e.g. simu.machine.rotor.slot.W0)
     if isinstance(value, str) and value[:4] == "simu":
         value_split = value.split(".")
         value = (
-            "lambda simu: getattr(eval('"
+            "lambda simu, val: setattr(eval('"
             + ".".join(value_split[:-1])
             + "'), '"
             + value_split[-1]
-            + "')"
+            + "', val"
+            + ")"
         )
     if value is None:
-        self._getter_str = None
-        self._getter_func = None
+        self._keeper_str = None
+        self._keeper_func = None
     elif isinstance(value, str) and "lambda" in value:
-        self._getter_str = value
-        self._getter_func = eval(value)
+        self._keeper_str = value
+        self._keeper_func = eval(value)
     elif isinstance(value, str) and value[-3:] == ".py":
         if "<" in value and ">" in value:
-            # path like "<PARAM_DIR>/setter_rotor.py"
-            self._getter_str = value
+            # path like "<PARAM_DIR>/keeper_rotor.py"
+            self._keeper_str = value
             value = abs_file_path(value)
         f = open(value, "r", encoding=PYTHON_DEFAULT_ENCODING)
         exec(f.read(), globals())
         f.close()
-        self._getter_func = eval(basename(value[:-3]))
+        self._keeper_func = eval(basename(value[:-3]))
     elif callable(value):
-        self._getter_str = None
-        self._getter_func = value
+        self._keeper_str = None
+        self._keeper_func = value
     else:
         raise CheckTypeError(
-            "For property getter Expected function or str (path to python file or lambda), got: "
+            "For property keeper Expected function or str (path to python file or lambda), got: "
             + str(type(value))
         )

--- a/pyleecan/Methods/Simulation/DataKeeper/_set_result.py
+++ b/pyleecan/Methods/Simulation/DataKeeper/_set_result.py
@@ -14,7 +14,7 @@ def _set_result(self, value):
                     class_obj = import_class(
                         "pyleecan.Classes", val.get("__class__"), "result_ref"
                     )
-                except:
+                except Exception:
                     class_obj = import_class(
                         "SciDataTool.Classes", val.get("__class__"), "result_ref"
                     )

--- a/pyleecan/Methods/Simulation/ParamExplorer/_set_setter.py
+++ b/pyleecan/Methods/Simulation/ParamExplorer/_set_setter.py
@@ -1,7 +1,7 @@
-from os.path import isfile
-from importlib import import_module
 from ....Classes._check import CheckTypeError
 from ntpath import basename
+from ....Functions.path_tools import abs_file_path
+from ....Generator import PYTHON_DEFAULT_ENCODING
 
 
 def _set_setter(self, value):
@@ -23,10 +23,14 @@ def _set_setter(self, value):
     elif isinstance(value, str) and "lambda" in value:
         self._setter_str = value
         self._setter_func = eval(value)
-    elif isinstance(value, str) and isfile(value) and value[-3:] == ".py":
-        self._setter_str = value
-        f = open(value, "r")
+    elif isinstance(value, str) and value[-3:] == ".py":
+        if "<" in value and ">" in value:
+            # path like "<PARAM_DIR>/setter_rotor.py"
+            self._setter_str = value
+            value = abs_file_path(value)
+        f = open(value, "r", encoding=PYTHON_DEFAULT_ENCODING)
         exec(f.read(), globals())
+        f.close()
         self._setter_func = eval(basename(value[:-3]))
     elif callable(value):
         self._setter_str = None


### PR DESCRIPTION
Improve setters and getters for ParamExplorer and DataKeeper to enable functions defined with relative path including global variables such as <PARAM_DIR>/relative_path.py
