### PR TITLE
[CC] allow dict keys with backslashes in h5

### DIFF
--- a/pyleecan/Functions/Load/load_hdf5.py
+++ b/pyleecan/Functions/Load/load_hdf5.py
@@ -74,6 +74,9 @@ def construct_dict_from_group(group):
             # Check if key is an int
             if is_int(key):
                 key = int(key)
+            # Convert key in case
+            if isinstance(key, str):
+                key = key.replace("\\x2F", "/")
             # Check if val is a group or a dataset
             if isinstance(val, Group):  # Group
                 # Call the function recursively to load group

--- a/pyleecan/Functions/Save/save_hdf5.py
+++ b/pyleecan/Functions/Save/save_hdf5.py
@@ -135,7 +135,7 @@ def variable_to_hdf5(file, prefix, variable, name):
     # Pyleecan object dict
     if isinstance(variable, dict):
         # Create group
-        group_name = prefix + "/" + name
+        group_name = prefix + "/" + name.replace("/", "\\x2F")
         file.create_group(group_name)
 
         # Call function to create groups and datasets recursively


### PR DESCRIPTION
In HDF5 groups are similar to file paths, i.e. there are backslashes in group paths.
This will cause issues if a dict has keys with backslashes in it. E.g. in an optimization where the objective is some ratio "x/y", the objective is stored in xoutput_dict with key "x/y". Then the result is saved without errors but can't loaded properly due to corrupted groups.
This PR fix this issue by converting backslashes in keys to "\\\x2F" and back.