### PR TITLE
Improvements on creation of geometry and meshing by GMSH

### DIFF
--- a/pyleecan/Functions/GMSH/draw_GMSH.py
+++ b/pyleecan/Functions/GMSH/draw_GMSH.py
@@ -49,7 +49,7 @@ def draw_GMSH(
     is_lam_only_R=False,
     user_mesh_dict={},
     path_save="GMSH_model.msh",
-    is_sliding_band=True,
+    is_sliding_band=False,
     is_airbox=False,
     is_set_labels=False,
     is_run=False,
@@ -540,30 +540,19 @@ def draw_GMSH(
                     if tid == 0:    
                         continue
                     stator_surf_gmsh_list.append((2, tid))
-
-                #stat_lam = stator_surf_gmsh_list.pop(0)
-                #print(rotor_ag_before, rotor_surf_gmsh_list)
-                #print(stator_ag_before, stat_lam, stator_surf_gmsh_list)
                 
                 cut1 = model.occ.cut([rotor_ag_before], rotor_surf_gmsh_list, removeObject=True, removeTool=False)
-                #cut2 = model.occ.cut([stator_ag_before], stator_surf_gmsh_list, removeObject=False, removeTool=False)
                 
                 # All These because CUT alone is not working for the stator
                 stat_copy = model.occ.copy(stator_surf_gmsh_list)
                 ints1 = model.occ.intersect([stator_ag_before],[stat_copy[0]],removeObject=True,removeTool=True,tag=-1)
                 stat_copy.pop(0)
                 cut2 = model.occ.cut(ints1[0],stat_copy,removeObject=True,removeTool=True,tag=-1)
-                
-                #print(cut1)
-                #print(cut2)
-                #print(stat_copy)
-                #print(fus1)
-                #print(fus2)
+
                 if len(cut1[0]) > 1:
                     # Remove extra surfaces
                     model.occ.remove([cut1[0][1]])
-                    factory.synchronize()
-                    
+                    factory.synchronize() 
                     pg = model.addPhysicalGroup(2, [cut1[0][0][1]])
                     model.setPhysicalName(2, pg, lab_int + "_" + AIRGAP_LAB + BOT_LAB)   
                 else:
@@ -639,8 +628,7 @@ def draw_GMSH(
                 if len(cut1[0]) > 1:
                     # Remove extra surfaces
                     model.occ.remove([cut1[0][0]])
-                    factory.synchronize()
-                    
+                    factory.synchronize()                 
                     pg = model.addPhysicalGroup(2, [cut1[0][1][1]])
                     model.setPhysicalName(2, pg, lab_int + "_" + AIRGAP_LAB + BOT_LAB)   
                 else:
@@ -658,8 +646,7 @@ def draw_GMSH(
                     factory.synchronize()
                     pg = model.addPhysicalGroup(2, [cut2[0][0][1]])
                     model.setPhysicalName(2, pg, lab_ext + "_" + AIRGAP_LAB + TOP_LAB)  
-                
-                
+                              
 
     ###################
     # Adding Airbox
@@ -752,9 +739,6 @@ def draw_GMSH(
             model.setPhysicalName(1, pg, label)
 
     
-
-
-
     # save mesh or geo file depending on file extension
     filename, file_extension = splitext(path_save)
 

--- a/pyleecan/Functions/GMSH/draw_GMSH.py
+++ b/pyleecan/Functions/GMSH/draw_GMSH.py
@@ -1,19 +1,30 @@
 from ...Classes.Arc import Arc
 from ...Classes.Arc2 import Arc2
 from ...Classes.MachineSIPMSM import MachineSIPMSM
+from ...Classes.MachineSCIM import MachineSCIM
+from ...Classes.MachineWRSM import MachineWRSM
 
 from ...Functions.labels import (
     HOLEM_LAB_S,
     MAG_LAB,
+    BAR_LAB,
     short_label,
     LAM_LAB,
+    YOKE_LAB,
+    WIND_LAB_S,
     LAM_LAB_S,
     SHAFT_LAB,
     decode_label,
     SLID_LAB,
     AIRGAP_LAB,
     BOT_LAB,
+    TOP_LAB,
     AIRBOX_LAB,
+    AIRBOX_R_LAB,
+    AR_B_LAB,
+    AR_T_LAB,
+    SBR_B_LAB,
+    SBR_T_LAB,
 )
 from ...Functions.GMSH import InputError
 from ...Functions.GMSH.get_sliding_band import get_sliding_band
@@ -29,7 +40,7 @@ from os.path import splitext
 
 from numpy import pi
 
-
+from ...Functions.get_logger import get_logger
 def draw_GMSH(
     output,
     sym,
@@ -91,10 +102,15 @@ def draw_GMSH(
     mesh_size_R = machine.rotor.Rext / 25.0  # Rotor
     mesh_size_SB = 2.0 * pi * machine.rotor.Rext / 360.0  # Sliding Band
     mesh_size_AB = machine.stator.Rext / 50.0  # AirBox
+    lam_list = machine.get_lam_list()
+    lam_int = lam_list[0]
+    lam_ext = lam_list[1]
+    lab_int = lam_int.get_label()
+    lab_ext = lam_ext.get_label()
 
     # For readibility
     model = gmsh.model
-    factory = model.geo
+    factory = model.occ
 
     # Start a new model
     gmsh.initialize()
@@ -132,6 +148,7 @@ def draw_GMSH(
             "with_holes": False,
             1: {
                 "tag": 0,
+                "label": None,
                 "n_elements": 1,
                 "bc_name": None,
                 "begin": {"tag": oo, "coord": complex(0.0, 0.0)},
@@ -148,7 +165,6 @@ def draw_GMSH(
     if not is_lam_only_S:
         for surf in rotor_list:
             nsurf += 1
-            # print(surf.label)
             gmsh_dict.update(
                 {
                     nsurf: {
@@ -172,7 +188,7 @@ def draw_GMSH(
                 surf,
                 mesh_dict,
                 boundary_prop,
-                factory,
+                model,
                 gmsh_dict,
                 nsurf,
                 mesh_size_R,
@@ -199,6 +215,7 @@ def draw_GMSH(
             if (
                 MAG_LAB in label_dict["surf_type"]
                 or HOLEM_LAB_S in label_dict["surf_type"]
+                or BAR_LAB in label_dict["surf_type"]
             ):
                 # Surface of Hole Magnet
                 rotor_cloops.extend([cloop])
@@ -209,7 +226,11 @@ def draw_GMSH(
             else:
                 # MachineSIPSM does not have holes in rotor lam
                 # only shaft is taken out if symmetry is one
-                if isinstance(machine, MachineSIPMSM):
+                if ( 
+                    isinstance(machine, MachineSIPMSM) 
+                    or isinstance(machine, MachineSCIM)
+                    or isinstance(machine, MachineWRSM)
+                ):
                     if sym == 1 and SHAFT_LAB in label_dict["surf_type"]:
                         lam_and_holes.extend([cloop])
                 else:
@@ -223,6 +244,7 @@ def draw_GMSH(
                 # Shaft, magnets and magnet pocket surfaces are created
                 if not is_lam_only_R:
                     s_data["tag"] = factory.addPlaneSurface([cloop], tag=-1)
+                    factory.synchronize()
                     pg = model.addPhysicalGroup(2, [s_data["tag"]])
                     model.setPhysicalName(2, pg, s_data["label"])
 
@@ -233,12 +255,14 @@ def draw_GMSH(
             gmsh_dict[lam_rotor_surf_id]["tag"] = factory.addPlaneSurface(
                 lam_and_holes, tag=-1
             )
+        factory.synchronize()
         pg = model.addPhysicalGroup(2, [gmsh_dict[lam_rotor_surf_id]["tag"]])
         model.setPhysicalName(2, pg, gmsh_dict[lam_rotor_surf_id]["label"])
         # rotor_cloops = lam_and_holes
 
     # store rotor dict
     rotor_dict = gmsh_dict.copy()
+    
 
     #####################
     # Adding Stator
@@ -251,6 +275,7 @@ def draw_GMSH(
             "with_holes": False,
             1: {
                 "tag": 0,
+                "label": None,
                 "n_elements": 1,
                 "bc_name": None,
                 "begin": {"tag": oo, "coord": complex(0.0, 0.0)},
@@ -288,7 +313,7 @@ def draw_GMSH(
                 surf,
                 mesh_dict,
                 boundary_prop,
-                factory,
+                model,
                 gmsh_dict,
                 nsurf,
                 mesh_size_S,
@@ -300,24 +325,66 @@ def draw_GMSH(
             if s_data["label"] == "origin":
                 continue
 
-            # build a lineloop of the surfaces lines
-            for lvalues in s_data.values():
-                if type(lvalues) is not dict:
-                    continue
-                lloop.extend([lvalues["tag"]])
-            cloop = factory.addCurveLoop(lloop)
-            stator_cloops.append(cloop)
+            if sym == 1:
+                inner_loop = []
+                # build a lineloop of the surfaces lines independently for yoke
+                # and bore is considered a hole
+                for lvalues in s_data.values():
+                    if type(lvalues) is not dict:
+                        continue
+                    
+                    if WIND_LAB_S in s_data["label"]:
+                        lloop.extend([lvalues["tag"]])
+                        inner_loop.extend([lvalues["tag"]])
+                    elif(
+                        lvalues["label"] is not None
+                        and LAM_LAB in lvalues["label"]
+                        and YOKE_LAB in lvalues["label"]
+                    ):
+                        lloop.extend([lvalues["tag"]])
+                    else:
+                        inner_loop.extend([lvalues["tag"]])    
+                #print(s_data["label"],lloop,inner_loop)
+                cloop = factory.addCurveLoop(lloop)
+                #stator_cloops.append(cloop)
 
-            # Winding surfaces are created
-            if LAM_LAB_S in decode_label(s_data["label"])["surf_type"] or (
-                not is_lam_only_S
-            ):
-                s_data["tag"] = factory.addPlaneSurface([cloop], tag=-1)
-                pg = model.addPhysicalGroup(2, [s_data["tag"]])
-                model.setPhysicalName(2, pg, s_data["label"])
+                
+                if LAM_LAB_S in decode_label(s_data["label"])["surf_type"] or (
+                    not is_lam_only_S
+                ):
+                    # Winding surfaces are created
+                    if WIND_LAB_S in s_data["label"]:
+                        s_data["tag"] = factory.addPlaneSurface([cloop], tag=-1)
+                        factory.synchronize()
+                        pg = model.addPhysicalGroup(2, [s_data["tag"]])
+                        model.setPhysicalName(2, pg, s_data["label"])
+                    # Lamination surfaces are created
+                    else:
+                        inner_cloop = factory.addCurveLoop(inner_loop)
+                        s_data["tag"] = factory.addPlaneSurface([cloop, inner_cloop], tag=-1)
+                        factory.synchronize()
+                        pg = model.addPhysicalGroup(2, [s_data["tag"]])
+                        model.setPhysicalName(2, pg, s_data["label"])
+            else:
+                for lvalues in s_data.values():
+                    if type(lvalues) is not dict:
+                        continue
+                    lloop.extend([lvalues["tag"]])
+                cloop = factory.addCurveLoop(lloop)
+                #stator_cloops.append(cloop)
 
-        # stator_dict = gmsh_dict.copy()
+                # All surfaces are created
+                if LAM_LAB_S in decode_label(s_data["label"])["surf_type"] or (
+                    not is_lam_only_S
+                ):
+                    s_data["tag"] = factory.addPlaneSurface([cloop], tag=-1)
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [s_data["tag"]])
+                    model.setPhysicalName(2, pg, s_data["label"])
 
+            
+
+    stator_dict = gmsh_dict.copy()
     gmsh_dict.update(rotor_dict)
 
     #####################
@@ -349,40 +416,250 @@ def draw_GMSH(
             surf,
             mesh_dict,
             boundary_prop,
-            factory,
+            model,
             gmsh_dict,
             nsurf,
             mesh_size_SB,
         )
 
-    for s_data in gmsh_dict.values():
-        lloop = []
-        label_dict = decode_label(s_data["label"])
+    if is_sliding_band and (not is_lam_only_R) and (not is_lam_only_S):
+        if sym == 1:
+            lloop1 = []
+            lloop2 = []
+            lloop3 = []
+            lloop4 = []
+            lloop5 = []
+            for s_data in gmsh_dict.values():            
+                label_dict = decode_label(s_data["label"])
 
-        # skip this surface dataset if it is the origin
-        if s_data["label"] == "origin" or not (
-            AIRGAP_LAB in label_dict["surf_type"] or SLID_LAB in label_dict["surf_type"]
-        ):
-            continue
+                # skip this surface dataset if it is the origin
+                if s_data["label"] == "origin" or not (
+                    AIRGAP_LAB in label_dict["surf_type"] or SLID_LAB in label_dict["surf_type"]
+                ):
+                    continue
 
-        # build a lineloop of the surfaces lines
-        for lvalues in s_data.values():
-            if type(lvalues) is not dict:
-                continue
-            lloop.extend([lvalues["tag"]])
+                # build a lineloop of the surfaces lines
+                for lvalues in s_data.values():
+                    if type(lvalues) is not dict:
+                        continue
+                    
+                    if (
+                        AIRGAP_LAB in label_dict["surf_type"]
+                        and BOT_LAB in label_dict["surf_type"]
+                        and AR_B_LAB in lvalues["label"]
+                    ):
+                        lloop1.extend([lvalues["tag"]])                 
+                    elif (
+                        SLID_LAB in label_dict["surf_type"]
+                        and BOT_LAB in label_dict["surf_type"]
+                        and SBR_B_LAB in lvalues["label"]
+                    ):
+                        lloop2.extend([lvalues["tag"]])  
+                    elif (
+                        SLID_LAB in label_dict["surf_type"]
+                        and TOP_LAB in label_dict["surf_type"]
+                        and SBR_T_LAB in lvalues["label"]
+                    ):
+                        lloop3.extend([lvalues["tag"]])  
+                    elif (
+                        AIRGAP_LAB in label_dict["surf_type"]
+                        and TOP_LAB in label_dict["surf_type"]
+                        and AR_T_LAB in lvalues["label"]
+                    ):
+                        lloop4.extend([lvalues["tag"]])  
+                    elif (
+                        AIRGAP_LAB in label_dict["surf_type"]
+                        and TOP_LAB in label_dict["surf_type"]
+                        and AIRBOX_R_LAB in lvalues["label"]
+                    ):
+                        lloop5.extend([lvalues["tag"]])
+                    else:    
+                        pass
+                
+            cloop1 = factory.addCurveLoop(lloop1)
+            cloop2 = factory.addCurveLoop(lloop2)
+            cloop3 = factory.addCurveLoop(lloop3)
+            cloop4 = factory.addCurveLoop(lloop4)
+            cloop5 = factory.addCurveLoop(lloop5)
+            
+            for s_data in gmsh_dict.values():
+                label_dict = decode_label(s_data["label"])
 
-        if lloop:
-            cloop = factory.addCurveLoop(lloop)
-            if (
-                AIRGAP_LAB in label_dict["surf_type"]
-                and BOT_LAB in label_dict["surf_type"]
-                and isinstance(machine, MachineSIPMSM)
-            ):
-                s_data["tag"] = factory.addPlaneSurface([cloop] + rotor_cloops, tag=-1)
-            else:
-                s_data["tag"] = factory.addPlaneSurface([cloop], tag=-1)
-            pg = model.addPhysicalGroup(2, [s_data["tag"]])
-            model.setPhysicalName(2, pg, s_data["label"])
+                # skip this surface dataset if it is the origin
+                if s_data["label"] == "origin" or not (
+                    AIRGAP_LAB in label_dict["surf_type"] or SLID_LAB in label_dict["surf_type"]
+                ):
+                    continue
+
+                if (
+                    AIRGAP_LAB in label_dict["surf_type"]
+                    and BOT_LAB in label_dict["surf_type"]
+                ):
+                    s_data["tag"] = factory.addPlaneSurface([cloop1], tag=-1)
+                    factory.synchronize()
+                    rotor_ag_before = (2,s_data["tag"])
+                elif (
+                    SLID_LAB in label_dict["surf_type"]
+                    and BOT_LAB in label_dict["surf_type"]
+                ):
+                    s_data["tag"] = factory.addPlaneSurface([cloop2, cloop1], tag=-1)
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [s_data["tag"]])
+                    model.setPhysicalName(2, pg, s_data["label"])                
+                elif (
+                    SLID_LAB in label_dict["surf_type"]
+                    and TOP_LAB in label_dict["surf_type"]
+                ):
+                    s_data["tag"] = factory.addPlaneSurface([cloop4, cloop3], tag=-1)
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [s_data["tag"]])
+                    model.setPhysicalName(2, pg, s_data["label"])
+                elif (
+                    AIRGAP_LAB in label_dict["surf_type"]
+                    and TOP_LAB in label_dict["surf_type"]
+                ):
+                    s_data["tag"] = factory.addPlaneSurface([cloop5, cloop4], tag=-1)
+                    #s_data["tag"] = factory.addPlaneSurface([cloop5], tag=-1)
+                    factory.synchronize()
+                    stator_ag_before = (2,s_data["tag"])
+                else:
+                    continue
+                
+
+            if is_sliding_band and (not is_lam_only_R) and (not is_lam_only_S):    
+                rotor_surf_gmsh_list = []
+                for tid in rotor_dict:
+                    # Discard Origin
+                    if tid == 0:    
+                        continue
+                    rotor_surf_gmsh_list.append((2, tid))
+
+                stator_surf_gmsh_list = []
+                for tid in stator_dict:
+                    # Discard Origin
+                    if tid == 0:    
+                        continue
+                    stator_surf_gmsh_list.append((2, tid))
+
+                #stat_lam = stator_surf_gmsh_list.pop(0)
+                #print(rotor_ag_before, rotor_surf_gmsh_list)
+                #print(stator_ag_before, stat_lam, stator_surf_gmsh_list)
+                
+                cut1 = model.occ.cut([rotor_ag_before], rotor_surf_gmsh_list, removeObject=True, removeTool=False)
+                #cut2 = model.occ.cut([stator_ag_before], stator_surf_gmsh_list, removeObject=False, removeTool=False)
+                
+                # All These because CUT alone is not working for the stator
+                stat_copy = model.occ.copy(stator_surf_gmsh_list)
+                ints1 = model.occ.intersect([stator_ag_before],[stat_copy[0]],removeObject=True,removeTool=True,tag=-1)
+                stat_copy.pop(0)
+                cut2 = model.occ.cut(ints1[0],stat_copy,removeObject=True,removeTool=True,tag=-1)
+                
+                #print(cut1)
+                #print(cut2)
+                #print(stat_copy)
+                #print(fus1)
+                #print(fus2)
+                if len(cut1[0]) > 1:
+                    # Remove extra surfaces
+                    model.occ.remove([cut1[0][1]])
+                    factory.synchronize()
+                    
+                    pg = model.addPhysicalGroup(2, [cut1[0][0][1]])
+                    model.setPhysicalName(2, pg, lab_int + "_" + AIRGAP_LAB + BOT_LAB)   
+                else:
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [cut1[0][0][1]])
+                    model.setPhysicalName(2, pg, lab_int + "_" + AIRGAP_LAB + BOT_LAB)  
+
+                if len(cut2[0]) > 1:
+                    # Remove extra surfaces
+                    model.occ.remove([cut2[0][0]])
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [cut2[0][1][1]])
+                    model.setPhysicalName(2, pg, lab_ext + "_" + AIRGAP_LAB + TOP_LAB)   
+                else:
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [cut2[0][0][1]])
+                    model.setPhysicalName(2, pg, lab_ext + "_" + AIRGAP_LAB + TOP_LAB)  
+                
+        else:
+            for s_data in gmsh_dict.values():
+                lloop = []
+                label_dict = decode_label(s_data["label"])
+
+                # skip this surface dataset if it is the origin
+                if s_data["label"] == "origin" or not (
+                    AIRGAP_LAB in label_dict["surf_type"] or SLID_LAB in label_dict["surf_type"]
+                ):
+                    continue
+
+                # build a lineloop of the surfaces lines
+                for lvalues in s_data.values():
+                    if type(lvalues) is not dict:
+                        continue
+                    lloop.extend([lvalues["tag"]])
+
+                if lloop:
+                    cloop = factory.addCurveLoop(lloop)
+                    if (
+                        AIRGAP_LAB in label_dict["surf_type"]
+                        and BOT_LAB in label_dict["surf_type"]
+                        and isinstance(machine, MachineSIPMSM)
+                    ):
+                        s_data["tag"] = factory.addPlaneSurface([cloop] + rotor_cloops, tag=-1)
+                    else:
+                        s_data["tag"] = factory.addPlaneSurface([cloop], tag=-1)
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [s_data["tag"]])
+                    model.setPhysicalName(2, pg, s_data["label"])          
+                    if (AIRGAP_LAB in s_data["label"] and BOT_LAB in s_data["label"]):
+                        rotor_ag_before = (2,s_data["tag"])
+                    if (AIRGAP_LAB in s_data["label"] and TOP_LAB in s_data["label"]):
+                        stator_ag_before = (2,s_data["tag"])
+                
+
+            if is_sliding_band and (not is_lam_only_R) and (not is_lam_only_S):    
+                rotor_surf_gmsh_list = []
+                for tid in rotor_dict:
+                    # Discard Origin
+                    if tid == 0:    
+                        continue
+                    rotor_surf_gmsh_list.append((2, tid))
+
+                stator_surf_gmsh_list = []
+                for tid in stator_dict:
+                    # Discard Origin
+                    if tid == 0:    
+                        continue
+                    stator_surf_gmsh_list.append((2, tid))
+
+                cut1 = model.occ.cut([rotor_ag_before], rotor_surf_gmsh_list, removeObject=True, removeTool=False)
+                cut2 = model.occ.cut([stator_ag_before], stator_surf_gmsh_list, removeObject=True, removeTool=False)
+
+                if len(cut1[0]) > 1:
+                    # Remove extra surfaces
+                    model.occ.remove([cut1[0][0]])
+                    factory.synchronize()
+                    
+                    pg = model.addPhysicalGroup(2, [cut1[0][1][1]])
+                    model.setPhysicalName(2, pg, lab_int + "_" + AIRGAP_LAB + BOT_LAB)   
+                else:
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [cut1[0][0][1]])
+                    model.setPhysicalName(2, pg, lab_int + "_" + AIRGAP_LAB + BOT_LAB)  
+
+                if len(cut2[0]) > 1:
+                    # Remove extra surfaces
+                    model.occ.remove([cut2[0][0]])
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [cut2[0][1][1]])
+                    model.setPhysicalName(2, pg, lab_ext + "_" + AIRGAP_LAB + TOP_LAB)   
+                else:
+                    factory.synchronize()
+                    pg = model.addPhysicalGroup(2, [cut2[0][0][1]])
+                    model.setPhysicalName(2, pg, lab_ext + "_" + AIRGAP_LAB + TOP_LAB)  
+                
+                
 
     ###################
     # Adding Airbox
@@ -434,6 +711,7 @@ def draw_GMSH(
         if lloop:
             cloop = factory.addCurveLoop(lloop)
             s_data["tag"] = factory.addPlaneSurface([cloop], tag=-1)
+            factory.synchronize()
             pg = model.addPhysicalGroup(2, [s_data["tag"]])
             model.setPhysicalName(2, pg, s_data["label"])
 
@@ -448,6 +726,7 @@ def draw_GMSH(
                 if lvalues["bc_name"] == propname:
                     bc_id.extend([abs(lvalues["tag"])])
         if bc_id:
+            factory.synchronize()
             pg = model.addPhysicalGroup(1, bc_id)
             model.setPhysicalName(1, pg, propname)
 
@@ -468,10 +747,13 @@ def draw_GMSH(
                 groups[lvalues["label"]].append(abs(lvalues["tag"]))
 
         for label, tags in groups.items():
+            factory.synchronize()
             pg = model.addPhysicalGroup(1, tags)
             model.setPhysicalName(1, pg, label)
 
-    factory.synchronize()
+    
+
+
 
     # save mesh or geo file depending on file extension
     filename, file_extension = splitext(path_save)

--- a/pyleecan/Functions/GMSH/draw_GMSH.py
+++ b/pyleecan/Functions/GMSH/draw_GMSH.py
@@ -73,7 +73,7 @@ def draw_GMSH(
     path_save : str
         Path to save the result msh file
     is_sliding_band : bool
-        True uses sliding band, else airgap (Not implemented yet)
+        True uses sliding band, else airgap 
     is_airbox : bool
         True to add the airbox
     is_set_label : bool

--- a/pyleecan/Functions/GMSH/draw_surf_line.py
+++ b/pyleecan/Functions/GMSH/draw_surf_line.py
@@ -1,8 +1,10 @@
 from .get_boundary_condition import get_boundary_condition
 from numpy import pi
 from ...Classes.Arc import Arc
+from ...Classes.Arc1 import Arc1
 from ...Classes.Arc2 import Arc2
 import cmath
+from ...Functions.labels import BOUNDARY_PROP_LAB
 
 tol = 1e-6
 
@@ -11,7 +13,7 @@ def draw_surf_line(
     surf,
     mesh_dict,
     boundary_prop,
-    factory,
+    model,
     gmsh_dict,
     nsurf,
     mesh_size,
@@ -39,25 +41,42 @@ def draw_surf_line(
         n_elem = mesh_dict[str(ii)]
         n_elem = n_elem if n_elem is not None else 0
         bc_name = get_boundary_condition(line, boundary_prop)
+        #print(surf.label , line.prop_dict, bc_name)
         # Gmsh built-in engine does not allow arcs larger than 180deg
         # so arcs are split into two
         if isinstance(line, Arc) and abs(line.get_angle() * 180.0 / pi) >= 180.0:
             rot_dir = 1 if line.is_trigo_direction == True else -1
-            arc1 = Arc2(
+            #print("Line ",line.get_begin(),line.get_center(),line.get_end(),line.get_angle(),line.comp_radius(),line.get_middle())
+            # arc1 = Arc2(
+            #     begin=line.get_begin(),
+            #     center=line.get_center(),
+            #     angle=rot_dir * pi / 2.0,
+            #     prop_dict=line.prop_dict,
+            # )
+            # arc2 = Arc2(
+            #     begin=arc1.get_end(),
+            #     center=line.get_center(),
+            #     angle=rot_dir * pi / 2.0,
+            #     prop_dict=line.prop_dict,
+            # )
+            arc1 = Arc1(
                 begin=line.get_begin(),
-                center=line.get_center(),
-                angle=rot_dir * pi / 2.0,
+                end=line.get_middle(),
+                radius=rot_dir * line.comp_radius(),
                 prop_dict=line.prop_dict,
+                is_trigo_direction=line.is_trigo_direction
             )
-            arc2 = Arc2(
-                begin=arc1.get_end(),
-                center=line.get_center(),
-                angle=rot_dir * pi / 2.0,
+            arc2 = Arc1(
+                begin=line.get_middle(),
+                end=line.get_end(),
+                radius=rot_dir * line.comp_radius(),
                 prop_dict=line.prop_dict,
+                is_trigo_direction=line.is_trigo_direction
             )
+            
             for arc in [arc1, arc2]:
                 _add_agline_to_dict(
-                    geo=factory,
+                    gmodel=model,
                     line=arc,
                     d=gmsh_dict,
                     idx=nsurf,
@@ -70,7 +89,7 @@ def draw_surf_line(
             pass
         else:
             _add_agline_to_dict(
-                geo=factory,
+                gmodel=model,
                 line=line,
                 d=gmsh_dict,
                 idx=nsurf,
@@ -80,7 +99,7 @@ def draw_surf_line(
             )
 
 
-def _add_agline_to_dict(geo, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc=None):
+def _add_agline_to_dict(gmodel, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc=None):
     """Draw a new Air Gap line and add it to GMSH dictionary if it does not exist
 
     Parameters
@@ -109,17 +128,25 @@ def _add_agline_to_dict(geo, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc
     btag, bx, by = _find_point_tag(d, line.get_begin())
     etag, ex, ey = _find_point_tag(d, line.get_end())
     if btag is None:
-        btag = geo.addPoint(bx, by, 0, meshSize=mesh_size, tag=-1)
+        btag = gmodel.occ.addPoint(bx, by, 0, meshSize=mesh_size, tag=-1)
     else:
         dlines.extend(_find_lines_from_point(d, btag))
     if etag is None:
-        etag = geo.addPoint(ex, ey, 0, meshSize=mesh_size, tag=-1)
+        etag = gmodel.occ.addPoint(ex, ey, 0, meshSize=mesh_size, tag=-1)
     else:
         dlines.extend(_find_lines_from_point(d, etag))
+
+    if (
+        line.prop_dict 
+        and BOUNDARY_PROP_LAB in line.prop_dict
+    ):
+        line_label = line.prop_dict[BOUNDARY_PROP_LAB]
+    else:
+        line_label = None
     if isinstance(line, Arc):
         ctag, cx, cy = _find_point_tag(d, line.get_center())
         if ctag is None:
-            ctag = geo.addPoint(cx, cy, 0, meshSize=mesh_size, tag=-1)
+            ctag = gmodel.occ.addPoint(cx, cy, 0, meshSize=mesh_size, tag=-1)
         else:
             dlines.extend(_find_lines_from_point(d, ctag))
         if len(dlines) > 0:
@@ -134,13 +161,15 @@ def _add_agline_to_dict(geo, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc
                 else:
                     pass
             if ltag is None:
-                ltag = geo.addCircleArc(btag, ctag, etag, tag=-1)
+                ltag = gmodel.occ.addCircleArc(btag, ctag, etag, tag=-1)
                 if n_elements > 0:
-                    geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+                    gmodel.occ.synchronize()
+                    gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
         else:
-            ltag = geo.addCircleArc(btag, ctag, etag, tag=-1)
+            ltag = gmodel.occ.addCircleArc(btag, ctag, etag, tag=-1)
             if n_elements > 0:
-                geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+                gmodel.occ.synchronize()
+                gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
 
         # To avoid fill the dictionary with repeated lines
         repeated = False
@@ -158,6 +187,7 @@ def _add_agline_to_dict(geo, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc
                 {
                     nline: {
                         "tag": ltag,
+                        "label": line_label,
                         "n_elements": n_elements,
                         "bc_name": bc,
                         "begin": {"tag": btag, "coord": complex(bx, by)},
@@ -182,13 +212,15 @@ def _add_agline_to_dict(geo, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc
                 else:
                     pass
             if ltag is None:
-                ltag = geo.addLine(btag, etag, tag=-1)
+                ltag = gmodel.occ.addLine(btag, etag, tag=-1)
                 if n_elements > 0:
-                    geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+                    gmodel.occ.synchronize()
+                    gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
         else:
-            ltag = geo.addLine(btag, etag, tag=-1)
+            ltag = gmodel.occ.addLine(btag, etag, tag=-1)
             if n_elements > 0:
-                geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+                gmodel.occ.synchronize()
+                gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
 
         # To avoid fill the dictionary with repeated lines
         repeated = False
@@ -208,6 +240,7 @@ def _add_agline_to_dict(geo, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc
                 {
                     nline: {
                         "tag": ltag,
+                        "label": line_label,
                         "n_elements": n_elements,
                         "bc_name": bc,
                         "begin": {"tag": btag, "coord": complex(bx, by)},
@@ -249,146 +282,150 @@ def _find_lines_from_point(d={}, ptag=-1):
     return lines
 
 
-def _add_line_to_dict(geo, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc=None):
-    """Draw a new line and add it to GMSH dictionary if it does not exist
+# def _add_line_to_dict(gmodel, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc=None):
+#     """Draw a new line and add it to GMSH dictionary if it does not exist
 
-    Parameters
-    ----------
-    geo : Model
-        GMSH Model objet
-    line : Object
-        Line Object
-    d : Dictionary
-        GMSH dictionary
-    idx : int
-        Surface index it belongs to
-    mesh_size : float
-        Points mesh size
-    n_elements : int
-        Number of elements on the line for meshing control
+#     Parameters
+#     ----------
+#     geo : Model
+#         GMSH Model objet
+#     line : Object
+#         Line Object
+#     d : Dictionary
+#         GMSH dictionary
+#     idx : int
+#         Surface index it belongs to
+#     mesh_size : float
+#         Points mesh size
+#     n_elements : int
+#         Number of elements on the line for meshing control
 
-    Returns
-    -------
-    None
-    """
+#     Returns
+#     -------
+#     None
+#     """
 
-    dlines = list()
-    ltag = None
-    btag, bx, by = _find_point_tag(d, line.get_begin())
-    etag, ex, ey = _find_point_tag(d, line.get_end())
-    if btag is None:
-        btag = geo.addPoint(bx, by, 0, meshSize=mesh_size, tag=-1)
-    else:
-        dlines.extend(_find_lines_from_point(d, btag))
-    if etag is None:
-        etag = geo.addPoint(ex, ey, 0, meshSize=mesh_size, tag=-1)
-    else:
-        dlines.extend(_find_lines_from_point(d, etag))
-    if isinstance(line, Arc):
-        ctag, cx, cy = _find_point_tag(d, line.get_center())
-        if ctag is None:
-            ctag = geo.addPoint(cx, cy, 0, meshSize=mesh_size, tag=-1)
-        else:
-            dlines.extend(_find_lines_from_point(d, ctag))
-        if len(dlines) > 0:
-            for iline in dlines:
-                p = _find_points_from_line(d, iline)
-                if p[0] == btag and p[1] == etag and p[2] == ctag:
-                    ltag = iline
-                    break
-                elif p[0] == etag and p[1] == btag and p[2] == ctag:
-                    ltag = -iline
-                    break
-                else:
-                    pass
-            if ltag is None:
-                ltag = geo.addCircleArc(btag, ctag, etag, tag=-1)
-                if n_elements > 0:
-                    geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
-        else:
-            ltag = geo.addCircleArc(btag, ctag, etag, tag=-1)
-            if n_elements > 0:
-                geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+#     dlines = list()
+#     ltag = None
+#     btag, bx, by = _find_point_tag(d, line.get_begin())
+#     etag, ex, ey = _find_point_tag(d, line.get_end())
+#     if btag is None:
+#         btag = gmodel.occ.addPoint(bx, by, 0, meshSize=mesh_size, tag=-1)
+#     else:
+#         dlines.extend(_find_lines_from_point(d, btag))
+#     if etag is None:
+#         etag = gmodel.occ.addPoint(ex, ey, 0, meshSize=mesh_size, tag=-1)
+#     else:
+#         dlines.extend(_find_lines_from_point(d, etag))
+#     if isinstance(line, Arc):
+#         ctag, cx, cy = _find_point_tag(d, line.get_center())
+#         if ctag is None:
+#             ctag = gmodel.occ.addPoint(cx, cy, 0, meshSize=mesh_size, tag=-1)
+#         else:
+#             dlines.extend(_find_lines_from_point(d, ctag))
+#         if len(dlines) > 0:
+#             for iline in dlines:
+#                 p = _find_points_from_line(d, iline)
+#                 if p[0] == btag and p[1] == etag and p[2] == ctag:
+#                     ltag = iline
+#                     break
+#                 elif p[0] == etag and p[1] == btag and p[2] == ctag:
+#                     ltag = -iline
+#                     break
+#                 else:
+#                     pass
+#             if ltag is None:
+#                 ltag = gmodel.occ.addCircleArc(btag, ctag, etag, tag=-1)
+#                 if n_elements > 0:
+#                     gmodel.occ.synchronize()
+#                     gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+#         else:
+#             ltag = gmodel.occ.addCircleArc(btag, ctag, etag, tag=-1)
+#             if n_elements > 0:
+#                 gmodel.occ.synchronize()
+#                 gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
 
-        # To avoid fill the dictionary with repeated lines
-        repeated = False
-        for lvalues in d[idx].values():
-            if type(lvalues) is not dict:
-                continue
-            else:
-                if lvalues["tag"] == ltag:
-                    repeated = True
+#         # To avoid fill the dictionary with repeated lines
+#         repeated = False
+#         for lvalues in d[idx].values():
+#             if type(lvalues) is not dict:
+#                 continue
+#             else:
+#                 if lvalues["tag"] == ltag:
+#                     repeated = True
 
-        if not repeated:
-            nline = len(d[idx]) - 2
-            arc_angle = cmath.phase(complex(ex, ey)) - cmath.phase(complex(bx, by))
-            d[idx].update(
-                {
-                    nline: {
-                        "tag": ltag,
-                        "n_elements": n_elements,
-                        "bc_name": bc,
-                        "begin": {"tag": btag, "coord": complex(bx, by)},
-                        "end": {"tag": etag, "coord": complex(ex, ey)},
-                        "cent": {"tag": ctag, "coord": complex(cx, cy)},
-                        "arc_angle": arc_angle,
-                        "line_angle": None,
-                        # "label": line.label,
-                    }
-                }
-            )
+#         if not repeated:
+#             nline = len(d[idx]) - 2
+#             arc_angle = cmath.phase(complex(ex, ey)) - cmath.phase(complex(bx, by))
+#             d[idx].update(
+#                 {
+#                     nline: {
+#                         "tag": ltag,
+#                         "n_elements": n_elements,
+#                         "bc_name": bc,
+#                         "begin": {"tag": btag, "coord": complex(bx, by)},
+#                         "end": {"tag": etag, "coord": complex(ex, ey)},
+#                         "cent": {"tag": ctag, "coord": complex(cx, cy)},
+#                         "arc_angle": arc_angle,
+#                         "line_angle": None,
+#                         # "label": line.label,
+#                     }
+#                 }
+#             )
 
-    else:
-        if len(dlines) > 0:
-            for iline in dlines:
-                p = _find_points_from_line(d, iline)
-                if p[0] == btag and p[1] == etag:
-                    ltag = iline
-                    break
-                elif p[0] == etag and p[1] == btag:
-                    ltag = -iline
-                    break
-                else:
-                    pass
-            if ltag is None:
-                ltag = geo.addLine(btag, etag, tag=-1)
-                if n_elements > 0:
-                    geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
-        else:
-            ltag = geo.addLine(btag, etag, tag=-1)
-            if n_elements > 0:
-                geo.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+#     else:
+#         if len(dlines) > 0:
+#             for iline in dlines:
+#                 p = _find_points_from_line(d, iline)
+#                 if p[0] == btag and p[1] == etag:
+#                     ltag = iline
+#                     break
+#                 elif p[0] == etag and p[1] == btag:
+#                     ltag = -iline
+#                     break
+#                 else:
+#                     pass
+#             if ltag is None:
+#                 ltag = gmodel.occ.addLine(btag, etag, tag=-1)
+#                 if n_elements > 0:
+#                     gmodel.occ.synchronize()
+#                     gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
+#         else:
+#             ltag = gmodel.occ.addLine(btag, etag, tag=-1)
+#             if n_elements > 0:
+#                 gmodel.occ.synchronize()
+#                 gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
 
-        # To avoid fill the dictionary with repeated lines
-        repeated = False
-        for lvalues in d[idx].values():
-            if type(lvalues) is not dict:
-                continue
-            else:
-                if lvalues["tag"] == ltag:
-                    repeated = True
+#         # To avoid fill the dictionary with repeated lines
+#         repeated = False
+#         for lvalues in d[idx].values():
+#             if type(lvalues) is not dict:
+#                 continue
+#             else:
+#                 if lvalues["tag"] == ltag:
+#                     repeated = True
 
-        if not repeated:
-            nline = len(d[idx]) - 2
-            line_angle = 0.5 * (
-                cmath.phase(complex(ex, ey)) + cmath.phase(complex(bx, by))
-            )
-            d[idx].update(
-                {
-                    nline: {
-                        "tag": ltag,
-                        "n_elements": n_elements,
-                        "bc_name": bc,
-                        "begin": {"tag": btag, "coord": complex(bx, by)},
-                        "end": {"tag": etag, "coord": complex(ex, ey)},
-                        "arc_angle": None,
-                        "line_angle": line_angle,
-                        # "label": line.label,
-                    }
-                }
-            )
+#         if not repeated:
+#             nline = len(d[idx]) - 2
+#             line_angle = 0.5 * (
+#                 cmath.phase(complex(ex, ey)) + cmath.phase(complex(bx, by))
+#             )
+#             d[idx].update(
+#                 {
+#                     nline: {
+#                         "tag": ltag,
+#                         "n_elements": n_elements,
+#                         "bc_name": bc,
+#                         "begin": {"tag": btag, "coord": complex(bx, by)},
+#                         "end": {"tag": etag, "coord": complex(ex, ey)},
+#                         "arc_angle": None,
+#                         "line_angle": line_angle,
+#                         # "label": line.label,
+#                     }
+#                 }
+#             )
 
-    return None
+#     return None
 
 
 def _find_point_tag(d={}, p=complex(0.0, 0.0)):

--- a/pyleecan/Functions/GMSH/draw_surf_line.py
+++ b/pyleecan/Functions/GMSH/draw_surf_line.py
@@ -41,24 +41,10 @@ def draw_surf_line(
         n_elem = mesh_dict[str(ii)]
         n_elem = n_elem if n_elem is not None else 0
         bc_name = get_boundary_condition(line, boundary_prop)
-        #print(surf.label , line.prop_dict, bc_name)
         # Gmsh built-in engine does not allow arcs larger than 180deg
         # so arcs are split into two
         if isinstance(line, Arc) and abs(line.get_angle() * 180.0 / pi) >= 180.0:
             rot_dir = 1 if line.is_trigo_direction == True else -1
-            #print("Line ",line.get_begin(),line.get_center(),line.get_end(),line.get_angle(),line.comp_radius(),line.get_middle())
-            # arc1 = Arc2(
-            #     begin=line.get_begin(),
-            #     center=line.get_center(),
-            #     angle=rot_dir * pi / 2.0,
-            #     prop_dict=line.prop_dict,
-            # )
-            # arc2 = Arc2(
-            #     begin=arc1.get_end(),
-            #     center=line.get_center(),
-            #     angle=rot_dir * pi / 2.0,
-            #     prop_dict=line.prop_dict,
-            # )
             arc1 = Arc1(
                 begin=line.get_begin(),
                 end=line.get_middle(),
@@ -72,8 +58,7 @@ def draw_surf_line(
                 radius=rot_dir * line.comp_radius(),
                 prop_dict=line.prop_dict,
                 is_trigo_direction=line.is_trigo_direction
-            )
-            
+            )  
             for arc in [arc1, arc2]:
                 _add_agline_to_dict(
                     gmodel=model,
@@ -280,152 +265,6 @@ def _find_lines_from_point(d={}, ptag=-1):
                 if pvalues["tag"] == ptag:
                     lines.append(lvalues["tag"])
     return lines
-
-
-# def _add_line_to_dict(gmodel, line, d={}, idx=0, mesh_size=1e-2, n_elements=0, bc=None):
-#     """Draw a new line and add it to GMSH dictionary if it does not exist
-
-#     Parameters
-#     ----------
-#     geo : Model
-#         GMSH Model objet
-#     line : Object
-#         Line Object
-#     d : Dictionary
-#         GMSH dictionary
-#     idx : int
-#         Surface index it belongs to
-#     mesh_size : float
-#         Points mesh size
-#     n_elements : int
-#         Number of elements on the line for meshing control
-
-#     Returns
-#     -------
-#     None
-#     """
-
-#     dlines = list()
-#     ltag = None
-#     btag, bx, by = _find_point_tag(d, line.get_begin())
-#     etag, ex, ey = _find_point_tag(d, line.get_end())
-#     if btag is None:
-#         btag = gmodel.occ.addPoint(bx, by, 0, meshSize=mesh_size, tag=-1)
-#     else:
-#         dlines.extend(_find_lines_from_point(d, btag))
-#     if etag is None:
-#         etag = gmodel.occ.addPoint(ex, ey, 0, meshSize=mesh_size, tag=-1)
-#     else:
-#         dlines.extend(_find_lines_from_point(d, etag))
-#     if isinstance(line, Arc):
-#         ctag, cx, cy = _find_point_tag(d, line.get_center())
-#         if ctag is None:
-#             ctag = gmodel.occ.addPoint(cx, cy, 0, meshSize=mesh_size, tag=-1)
-#         else:
-#             dlines.extend(_find_lines_from_point(d, ctag))
-#         if len(dlines) > 0:
-#             for iline in dlines:
-#                 p = _find_points_from_line(d, iline)
-#                 if p[0] == btag and p[1] == etag and p[2] == ctag:
-#                     ltag = iline
-#                     break
-#                 elif p[0] == etag and p[1] == btag and p[2] == ctag:
-#                     ltag = -iline
-#                     break
-#                 else:
-#                     pass
-#             if ltag is None:
-#                 ltag = gmodel.occ.addCircleArc(btag, ctag, etag, tag=-1)
-#                 if n_elements > 0:
-#                     gmodel.occ.synchronize()
-#                     gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
-#         else:
-#             ltag = gmodel.occ.addCircleArc(btag, ctag, etag, tag=-1)
-#             if n_elements > 0:
-#                 gmodel.occ.synchronize()
-#                 gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
-
-#         # To avoid fill the dictionary with repeated lines
-#         repeated = False
-#         for lvalues in d[idx].values():
-#             if type(lvalues) is not dict:
-#                 continue
-#             else:
-#                 if lvalues["tag"] == ltag:
-#                     repeated = True
-
-#         if not repeated:
-#             nline = len(d[idx]) - 2
-#             arc_angle = cmath.phase(complex(ex, ey)) - cmath.phase(complex(bx, by))
-#             d[idx].update(
-#                 {
-#                     nline: {
-#                         "tag": ltag,
-#                         "n_elements": n_elements,
-#                         "bc_name": bc,
-#                         "begin": {"tag": btag, "coord": complex(bx, by)},
-#                         "end": {"tag": etag, "coord": complex(ex, ey)},
-#                         "cent": {"tag": ctag, "coord": complex(cx, cy)},
-#                         "arc_angle": arc_angle,
-#                         "line_angle": None,
-#                         # "label": line.label,
-#                     }
-#                 }
-#             )
-
-#     else:
-#         if len(dlines) > 0:
-#             for iline in dlines:
-#                 p = _find_points_from_line(d, iline)
-#                 if p[0] == btag and p[1] == etag:
-#                     ltag = iline
-#                     break
-#                 elif p[0] == etag and p[1] == btag:
-#                     ltag = -iline
-#                     break
-#                 else:
-#                     pass
-#             if ltag is None:
-#                 ltag = gmodel.occ.addLine(btag, etag, tag=-1)
-#                 if n_elements > 0:
-#                     gmodel.occ.synchronize()
-#                     gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
-#         else:
-#             ltag = gmodel.occ.addLine(btag, etag, tag=-1)
-#             if n_elements > 0:
-#                 gmodel.occ.synchronize()
-#                 gmodel.mesh.setTransfiniteCurve(ltag, n_elements + 1, "Progression")
-
-#         # To avoid fill the dictionary with repeated lines
-#         repeated = False
-#         for lvalues in d[idx].values():
-#             if type(lvalues) is not dict:
-#                 continue
-#             else:
-#                 if lvalues["tag"] == ltag:
-#                     repeated = True
-
-#         if not repeated:
-#             nline = len(d[idx]) - 2
-#             line_angle = 0.5 * (
-#                 cmath.phase(complex(ex, ey)) + cmath.phase(complex(bx, by))
-#             )
-#             d[idx].update(
-#                 {
-#                     nline: {
-#                         "tag": ltag,
-#                         "n_elements": n_elements,
-#                         "bc_name": bc,
-#                         "begin": {"tag": btag, "coord": complex(bx, by)},
-#                         "end": {"tag": etag, "coord": complex(ex, ey)},
-#                         "arc_angle": None,
-#                         "line_angle": line_angle,
-#                         # "label": line.label,
-#                     }
-#                 }
-#             )
-
-#     return None
 
 
 def _find_point_tag(d={}, p=complex(0.0, 0.0)):

--- a/pyleecan/Functions/GMSH/draw_surf_line.py
+++ b/pyleecan/Functions/GMSH/draw_surf_line.py
@@ -28,14 +28,18 @@ def draw_surf_line(
         Dictionary to enforce the mesh (key: line id, value:nb element)
     boundary_prop : dict
         Dictionary to set the Boundary conditions
-    factory :
-        gmsh.model.geo
+    model : Object
+        Gmsh model
     gmsh_dict: dict
         dictionary containing the main parameters of GMSH File
     nsurf : int
         Index of the surface to draw
     mesh_size: float
         Default mesh element size
+
+    Returns
+    -------
+    None
     """
     for ii, line in enumerate(surf.get_lines()):
         n_elem = mesh_dict[str(ii)]
@@ -89,8 +93,8 @@ def _add_agline_to_dict(gmodel, line, d={}, idx=0, mesh_size=1e-2, n_elements=0,
 
     Parameters
     ----------
-    geo : Model
-        GMSH Model objet
+    gmodel : Object
+        GMSH Model object
     line : Object
         Line Object
     d : Dictionary
@@ -101,6 +105,8 @@ def _add_agline_to_dict(gmodel, line, d={}, idx=0, mesh_size=1e-2, n_elements=0,
         Points mesh size
     n_elements : int
         Number of elements on the line for meshing control
+    bc : String
+        Boundary condition name
 
     Returns
     -------

--- a/pyleecan/Functions/GMSH/get_sliding_band.py
+++ b/pyleecan/Functions/GMSH/get_sliding_band.py
@@ -41,10 +41,8 @@ def get_sliding_band(sym, machine):
     ----------
     sym: int
         Symmetry factor (1= full machine, 2= half of the machine...)
-    Rgap_mec_int: float
-        Internal lamination mechanic radius
-    Rgap_mec_ext: float
-        External lamination mechanic radius
+    machine: Machine
+        Machine to draw
 
     Returns
     -------

--- a/pyleecan/Functions/GMSH/get_sliding_band.py
+++ b/pyleecan/Functions/GMSH/get_sliding_band.py
@@ -8,10 +8,12 @@ from ...Classes.Arc2 import Arc2
 from ...Classes.Circle import Circle
 from ...Classes.Segment import Segment
 from ...Classes.SurfLine import SurfLine
+from ...Classes.SurfRing import SurfRing
 from ...Classes.MachineSIPMSM import MachineSIPMSM
 from ...Functions.labels import (
     AIRGAP_LAB,
     SLID_LAB,
+    AIRBOX_LAB,
     NO_LAM_LAB,
     BOT_LAB,
     TOP_LAB,
@@ -28,6 +30,7 @@ from ...Functions.labels import (
     AS_BL_LAB,
     AR_B_LAB,
     AR_T_LAB,
+    AIRBOX_R_LAB,
 )
 
 
@@ -54,162 +57,93 @@ def get_sliding_band(sym, machine):
     lab_int = lam_int.get_label()
     lab_ext = lam_ext.get_label()
 
-    stator_list = machine.stator.build_geometry(sym=sym)
-    rotor_list = machine.rotor.build_geometry(sym=sym)
-    slot_height = machine.stator.slot.comp_height()
-    wind_slot_height = machine.stator.slot.comp_height_active()
-    wedge_height = slot_height - wind_slot_height
     Rgap_mec_int = lam_int.comp_radius_mec()
     Rgap_mec_ext = lam_ext.comp_radius_mec()
-    Rgap_mag_int = lam_int.Rext
-    Rgap_mag_ext = lam_ext.Rint
     Sor = lam_ext.Rext
     Wgap_mec = Rgap_mec_ext - Rgap_mec_int
     W_sb = Wgap_mec / 4  # Width sliding band
     tol = 0.1e-3  # Tolerance
-    max_radius_Airgap_ext = Rgap_mec_ext + wedge_height + tol
-    min_radius_Airgap_int = Rgap_mec_int - tol
 
-    # Find lines that are between Stator Inner Diam and slot wedge area
-    stator_airgap_ext_lines = list()
-    first_points = list()  # To check the loop and find inverted lines
-    for surf in stator_list:
-        for line in surf.get_lines():
-            p1 = line.get_begin()
-            p2 = line.get_end()
-            if abs(p1) < max_radius_Airgap_ext and abs(p2) < max_radius_Airgap_ext:
-                r_p1, phi_p1 = cmath.polar(p1)
-                r_p2, phi_p2 = cmath.polar(p2)
-                if isinstance(line, Arc):
-                    p3 = line.get_center()
-                    r_p3, phi_p3 = cmath.polar(p3)
-                    radius = r_p1 - r_p3
-                    line_copy = Arc1(
-                        begin=p1,
-                        end=p2,
-                        radius=radius,
-                        prop_dict=line.prop_dict,
-                        is_trigo_direction=True,
-                    )
-                    # if phi_p2 > phi_p1:
-                    #    line_copy.reverse()
-                else:
-                    line_copy = Segment(begin=p1, end=p2, prop_dict=line.prop_dict)
-                new_p1 = p1
-                for p in first_points:
-                    if abs(p1.real - p.real) < tol and abs(p1.imag - p.imag) < tol:
-                        line_copy.reverse()
-                        new_p1 = p2
-                        break
-                stator_airgap_ext_lines.append(line_copy)
-                first_points.append(new_p1)
-
-    # Find lines that are between Rotor Outer Diam and ...
-    rotor_airgap_int_lines = list()
-    if isinstance(machine, MachineSIPMSM):
-        min_radius_Airgap_int = min(Rgap_mec_int, Rgap_mag_int) - tol
-        for surf in rotor_list:
-            if "Magnet" in surf.label:
-                continue
-            for line in surf.get_lines():
-                if line.comp_length() < tol:
-                    continue
-                p1 = line.get_begin()
-                p2 = line.get_end()
-
-                if abs(p1) > min_radius_Airgap_int and abs(p2) > min_radius_Airgap_int:
-                    r_p1, phi_p1 = cmath.polar(p1)
-                    r_p2, phi_p2 = cmath.polar(p2)
-                    if isinstance(line, Arc):
-                        p3 = line.get_center()
-                        r_p3, phi_p3 = cmath.polar(p3)
-                        radius = r_p1 - r_p3
-                        line_copy = Arc1(
-                            begin=p1,
-                            end=p2,
-                            radius=radius,
-                            prop_dict=line.prop_dict,
-                            is_trigo_direction=True,
-                        )
-                        if phi_p2 > phi_p1:
-                            line_copy.reverse()
-                    else:
-                        line_copy = Segment(begin=p1, end=p2, prop_dict=line.prop_dict)
-                        if phi_p2 > phi_p1:
-                            line_copy.reverse()
-                    rotor_airgap_int_lines.append(line_copy)
-    else:
-        for surf in rotor_list:
-            for line in surf.get_lines():
-                p1 = line.get_begin()
-                p2 = line.get_end()
-                if abs(p1) > min_radius_Airgap_int and abs(p2) > min_radius_Airgap_int:
-                    r_p1, phi_p1 = cmath.polar(p1)
-                    r_p2, phi_p2 = cmath.polar(p2)
-                    if isinstance(line, Arc):
-                        p3 = line.get_center()
-                        r_p3, phi_p3 = cmath.polar(p3)
-                        radius = r_p1 - r_p3
-                        line_copy = Arc1(
-                            begin=p1,
-                            end=p2,
-                            radius=radius,
-                            prop_dict=line.prop_dict,
-                            is_trigo_direction=True,
-                        )
-                        if phi_p2 > phi_p1:
-                            line_copy.reverse()
-                    else:
-                        line_copy = Segment(begin=p1, end=p2, prop_dict=line.prop_dict)
-                        if phi_p2 > phi_p1:
-                            line_copy.reverse()
-                    rotor_airgap_int_lines.append(line_copy)
 
     surf_list = list()
     if sym == 1:  # Complete machine
-        # TODO: Sliding Band Full Machine no implemented yet.
         # Internal AirGap
-        surf_list.append(
-            Circle(
+        int_airgap_cir = Circle(
                 center=0,
                 radius=Rgap_mec_int + W_sb,
                 label=lab_int + "_" + AIRGAP_LAB + BOT_LAB,
                 point_ref=(Rgap_mec_int + W_sb / 2) * exp(1j * pi / 2),
                 prop_dict={BOUNDARY_PROP_LAB: AR_B_LAB},
-            )
         )
+        surf_list.append(int_airgap_cir)
         # Internal Sliding band
-        surf_list.append(
-            Circle(
+        int_sb_cir = Circle(
                 center=0,
-                radius=Rgap_mec_int + 2 * W_sb,
-                label=NO_LAM_LAB + "_" + SLID_LAB,
+                radius=Rgap_mec_int + 2 * W_sb - tol / 10,
+                label=NO_LAM_LAB + "_" + SLID_LAB + BOT_LAB,
                 point_ref=(Rgap_mec_ext - W_sb / 2) * exp(1j * pi / 2),
                 prop_dict={BOUNDARY_PROP_LAB: SBR_B_LAB},
-            )
         )
-        # External AirGap
         surf_list.append(
-            Circle(
+            SurfRing(
+                out_surf=int_sb_cir,
+                in_surf=int_airgap_cir,
+                label=NO_LAM_LAB + "_" + SLID_LAB + BOT_LAB,
+                point_ref=(Rgap_mec_ext - W_sb / 2) * exp(1j * pi / 2),
+            )            
+        )
+        ext_sb_cir = Circle(
+                center=0,
+                radius=Rgap_mec_int + 2 * W_sb + tol / 10,
+                label=NO_LAM_LAB + "_" + SLID_LAB + TOP_LAB,
+                point_ref=(Rgap_mec_ext - W_sb / 2) * exp(1j * pi / 2),
+                prop_dict={BOUNDARY_PROP_LAB: SBR_T_LAB},
+        )
+        ext_airgap_cir = Circle(
                 center=0,
                 radius=Rgap_mec_int + 3 * W_sb,
                 label=lab_ext + "_" + AIRGAP_LAB + TOP_LAB,
                 point_ref=(Rgap_mec_ext - W_sb / 2) * exp(1j * pi / 2),
                 prop_dict={BOUNDARY_PROP_LAB: AR_T_LAB},
+        )
+        # External Sliding band
+        surf_list.append(
+            SurfRing(
+                out_surf=ext_airgap_cir,
+                in_surf=ext_sb_cir,
+                label=NO_LAM_LAB + "_" + SLID_LAB + TOP_LAB,
+                point_ref=(Rgap_mec_ext - W_sb / 2) * exp(1j * pi / 2),
+            )            
+        )
+        lam_ext_cir = Circle(
+                center=0,
+                radius=1.1*Rgap_mec_ext, # Hopefully enough to reach the windings
+                label=lab_ext + "_" + AIRBOX_LAB + BOT_LAB,
+                point_ref=(Rgap_mec_ext - W_sb / 2) * exp(1j * pi / 2),
+                prop_dict={BOUNDARY_PROP_LAB: AIRBOX_R_LAB},
+        )
+        # External AirGap
+        surf_list.append(
+            SurfRing(
+                out_surf=lam_ext_cir,
+                in_surf=ext_airgap_cir,
+                label=lab_ext + "_" + AIRGAP_LAB + TOP_LAB,
+                point_ref=(Rgap_mec_ext - W_sb / 2) * exp(1j * pi / 2),
             )
         )
 
     else:  # Symmetry
         # Internal AirGap
-        Z1 = Rgap_mec_int
-        if isinstance(machine, MachineSIPMSM):
-            Z1 = Rgap_mag_int
-        Z0 = Z1 * exp(1j * 2 * pi / sym)
+        #Z1 = Rgap_mec_int
+        #if isinstance(machine, MachineSIPMSM):
+        #    Z1 = Rgap_mag_int
+        #Z0 = Z1 * exp(1j * 2 * pi / sym)
+        Z0 = 0 * exp(1j * 2 * pi / sym)
         Z2 = Rgap_mec_int + W_sb
         Z3 = Z2 * exp(1j * 2 * pi / sym)
         airgap_lines = list()
         airgap_lines.append(
-            Segment(begin=Z1, end=Z2, prop_dict={BOUNDARY_PROP_LAB: AS_BR_LAB})
+            Segment(begin=Z0, end=Z2, prop_dict={BOUNDARY_PROP_LAB: AS_BR_LAB})
         )
         int_airgap_arc = Arc1(
             begin=Z2,
@@ -222,7 +156,7 @@ def get_sliding_band(sym, machine):
         airgap_lines.append(
             Segment(begin=Z3, end=Z0, prop_dict={BOUNDARY_PROP_LAB: AS_BL_LAB})
         )
-        airgap_lines.extend(rotor_airgap_int_lines)
+        #airgap_lines.extend(rotor_airgap_int_lines)
         surf_list.append(
             SurfLine(
                 line_list=airgap_lines,
@@ -241,7 +175,7 @@ def get_sliding_band(sym, machine):
         int_sb_arc = Arc1(
             begin=Z4,
             end=Z5,
-            radius=Rgap_mec_int + 2 * W_sb,
+            radius=Rgap_mec_int + 2 * W_sb - tol / 10,
             prop_dict={BOUNDARY_PROP_LAB: SBR_B_LAB},
             is_trigo_direction=True,
         )
@@ -289,7 +223,7 @@ def get_sliding_band(sym, machine):
         ext_sb_arc = Arc1(
             begin=Z6,
             end=Z7,
-            radius=Rgap_mec_int + 2 * W_sb,
+            radius=Rgap_mec_int + 2 * W_sb + tol / 10,
             # label="ext_sb_arc",
             is_trigo_direction=True,
         )
@@ -304,12 +238,21 @@ def get_sliding_band(sym, machine):
         )
 
         # External AirGap
-        Z10 = Rgap_mec_ext
+        #Z10 = Rgap_mec_ext
+        Z10 = Sor
         Z11 = Z10 * exp(1j * 2 * pi / sym)
         airgap_lines = list()
         airgap_lines.append(
             Segment(begin=Z8, end=Z10, prop_dict={BOUNDARY_PROP_LAB: AS_TR_LAB})
         )
+        lam_ext_arc = Arc1(
+            begin=Z10,
+            end=Z11,
+            radius=Sor,
+            # label="int_airgap_arc_copy",
+            is_trigo_direction=True,
+        )
+        airgap_lines.append(lam_ext_arc)
         airgap_lines.append(
             Segment(begin=Z11, end=Z9, prop_dict={BOUNDARY_PROP_LAB: AS_TL_LAB})
         )
@@ -323,7 +266,7 @@ def get_sliding_band(sym, machine):
         )
         ext_airgap_arc_copy.reverse()
         airgap_lines.append(ext_airgap_arc_copy)
-        airgap_lines.extend(stator_airgap_ext_lines)
+        #airgap_lines.extend(stator_airgap_ext_lines)
         surf_list.append(
             SurfLine(
                 line_list=airgap_lines,
@@ -331,5 +274,4 @@ def get_sliding_band(sym, machine):
                 label=lab_ext + "_" + AIRGAP_LAB + TOP_LAB,
             )
         )
-
     return surf_list

--- a/pyleecan/Functions/GMSH/get_sliding_band.py
+++ b/pyleecan/Functions/GMSH/get_sliding_band.py
@@ -134,10 +134,6 @@ def get_sliding_band(sym, machine):
 
     else:  # Symmetry
         # Internal AirGap
-        #Z1 = Rgap_mec_int
-        #if isinstance(machine, MachineSIPMSM):
-        #    Z1 = Rgap_mag_int
-        #Z0 = Z1 * exp(1j * 2 * pi / sym)
         Z0 = 0 * exp(1j * 2 * pi / sym)
         Z2 = Rgap_mec_int + W_sb
         Z3 = Z2 * exp(1j * 2 * pi / sym)
@@ -156,7 +152,7 @@ def get_sliding_band(sym, machine):
         airgap_lines.append(
             Segment(begin=Z3, end=Z0, prop_dict={BOUNDARY_PROP_LAB: AS_BL_LAB})
         )
-        #airgap_lines.extend(rotor_airgap_int_lines)
+
         surf_list.append(
             SurfLine(
                 line_list=airgap_lines,
@@ -238,7 +234,6 @@ def get_sliding_band(sym, machine):
         )
 
         # External AirGap
-        #Z10 = Rgap_mec_ext
         Z10 = Sor
         Z11 = Z10 * exp(1j * 2 * pi / sym)
         airgap_lines = list()
@@ -266,7 +261,6 @@ def get_sliding_band(sym, machine):
         )
         ext_airgap_arc_copy.reverse()
         airgap_lines.append(ext_airgap_arc_copy)
-        #airgap_lines.extend(stator_airgap_ext_lines)
         surf_list.append(
             SurfLine(
                 line_list=airgap_lines,


### PR DESCRIPTION
This pull request will improve the geometry and mesh generation through gmsh. The code has been rewritten to use OCC kernel instead, and this allows to perform boolean operations for the better creation of surfaces in the air gap. The sliding band is being drawn in such a way that is compatible with the magnetics solvers in Elmer fem.
Additionally, this pull request will allow to create and mesh almost all the example geometries available in the database: 
 pyleecan/Data/Machine .
There will be future improvements to support outer rotor topologies. Currently, the outer rotor geometries can be drawn without sliding band.
I am also trying to identify and fix some of the boundary condition settings that seems to be inconsistent with how those are currently treated in pyleecan.
GUI has a button to create gmsh file and default to sym=1, it would be good that defaults to is_sliding_band=False and is_airbox=False too.